### PR TITLE
Upgrade to pyxform v1.1.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       test: [ "CMD-SHELL", "nc -z localhost 443 || exit 1" ]
   pyxform:
     container_name: pyxform
-    image: 'yanokwa/pyxform-http:v0.3.0'
+    image: 'yanokwa/pyxform-http:v1.0.0'
 volumes:
   transfer:
 


### PR DESCRIPTION
As requested, @lognaturel. The commits since v0.3.0 are at https://github.com/yanokwa/pyxform-http/compare/v0.3.0...master. The key changes are 
1. Add support for external itemsets csv https://github.com/yanokwa/pyxform-http/pull/8
1. Upgrade to pyxform v1.x https://github.com/yanokwa/pyxform-http/commit/fdf50cde5dc4109869aa5e52db72ab39449c01ed

I propose that you approve and @issa-tseng merge.