### PR TITLE
Support auto-restarting docker-compose stack on system reboot

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       POSTGRES_USER: odk
       POSTGRES_PASSWORD: odk
       POSTGRES_DATABASE: odk
+    restart: always
   mail:
     container_name: mail
     image: "itsissa/namshi-smtp:4.89-2.deb9u5"
@@ -16,6 +17,7 @@ services:
       - ./files/dkim/rsa.private:/etc/exim4/domain.key:ro
     environment:
       - MAILNAME=${DOMAIN}
+    restart: always
   service:
     container_name: service
     build:
@@ -29,6 +31,7 @@ services:
     environment:
       - DOMAIN=${DOMAIN}
     command: [ "./wait-for-it.sh", "postgres:5432", "--", "./start-odk.sh" ]
+    restart: always
   nginx:
     container_name: nginx
     build:
@@ -45,9 +48,11 @@ services:
       - "443:443"
     healthcheck:
       test: [ "CMD-SHELL", "nc -z localhost 443 || exit 1" ]
+    restart: always
   pyxform:
     container_name: pyxform
     image: 'getodk/pyxform-http:v1.0.0'
+    restart: always
 volumes:
   transfer:
 


### PR DESCRIPTION
The docs currently state in order to support auto-restart on system reboot, a systemd script must be installed.
This might ( and has in my case ) caused permission issues in the event the user running the docker commands isn't a root user

We can easily support auto-restart by adding the restart: always entry in the docker-compose service and enabling the docker service for systemd