### PR TITLE
enketo: update to 2.3.12 for lower memory reqs on build

### DIFF
--- a/enketo.dockerfile
+++ b/enketo.dockerfile
@@ -1,4 +1,4 @@
-FROM enketo/enketo-express:2.3.11
+FROM enketo/enketo-express:2.3.12
 
 ENV ENKETO_SRC_DIR=/srv/src/enketo_express
 WORKDIR ${ENKETO_SRC_DIR}


### PR DESCRIPTION
I've verified the diff from 2.3.11 to 2.3.12 and have confirmed there's nothing risky. I'm not sure the best way to try building this on a 1gb DO droplet and am hoping @yanokwa or @matthew-white can quickly do that.