### PR TITLE
docs: add explicit link to development setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you are looking for help, please take a look at the [Documentation Website](h
 Contributing
 ============
 
-We would love your contributions to Central. If you have thoughts or suggestions, please share them with us on the [Features board](https://forum.getodk.org/c/features) on the ODK Forum. If you wish to contribute code, you have the option of working on the Backend server ([contribution guide](https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md)), the Frontend website ([contribution guide](https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md)), or both.
+We would love your contributions to Central. If you have thoughts or suggestions, please share them with us on the [Features board](https://forum.getodk.org/c/features) on the ODK Forum. If you wish to contribute code, you have the option of working on the Backend server ([contribution guide](https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md)), the Frontend website ([contribution guide](https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md)), or both. To set up a development environment, first follow the [Backend instructions](https://github.com/getodk/central-backend#setting-up-a-development-environment) and then optionally the [Frontend instructions](https://github.com/getodk/central-frontend#running-in-development).
 
 Operations
 ==========

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Contributing
 
 We would love your contributions to Central. If you have thoughts or suggestions, please share them with us on the [Features board](https://forum.getodk.org/c/features) on the ODK Forum. If you wish to contribute code, you have the option of working on the Backend server ([contribution guide](https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md)), the Frontend website ([contribution guide](https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md)), or both. To set up a development environment, first follow the [Backend instructions](https://github.com/getodk/central-backend#setting-up-a-development-environment) and then optionally the [Frontend instructions](https://github.com/getodk/central-frontend#running-in-development).
 
+Central relies on [pyxform-http](https://github.com/getodk/pyxform-http) for converting forms from XLSForm. It generally shouldn't be needed in development but can be run locally. Central also relies on [Enketo](https://github.com/enketo/enketo-express) for web form functionality. The Enketo integration uses Central's cookie auth for a seamless user experience and cookie auth is only available when Central uses HTTPS. For this reason, we typically don't recommend trying to run Enketo in development. Instead, you can drive local development that integrates with Enketo using tests and then try new functionality in a [production environment](https://docs.getodk.org/central-install-digital-ocean/) by [checking out a commit](https://docs.getodk.org/central-upgrade/) from your fork. Be sure to follow the upgrade instructions exactly. In particular, do not run `docker-compose down` because this will recreate new volumes instead of using existing ones.
+
 Operations
 ==========
 


### PR DESCRIPTION
It's definitely possible to get to the dev setup instructions from the contributing guides for frontend and backend but it's disorienting not to have them front and center.