### PR TITLE
Change to more generic email address

### DIFF
--- a/files/enketo/config.json.template
+++ b/files/enketo/config.json.template
@@ -32,7 +32,7 @@
         }
     },
     "support": {
-        "email": "errors@getodk.org"
+        "email": "support@getodk.org"
     },
     "text field character limit": 1000000
 }


### PR DESCRIPTION
We use support@getodk.org everywhere now and I think it's ultimately a better email address for this kind of issue.