### PR TITLE
Update pyxform-http to 1.5.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
 
   pyxform:
     container_name: pyxform
-    image: 'getodk/pyxform-http:v1.3.4'
+    image: 'getodk/pyxform-http:v1.5.0'
     restart: always
 
   secrets:


### PR DESCRIPTION
Key improvements
* Upgrade to pyxform v1.5.0
* Switch to gunicorn to reduce memory leaks and use older binaries for smaller size
* Upgrade deps, support for percent-coded form ids

I have not actually tested this PR inside Central, but risk should be pretty low. It'd be nice if this could be put though it's paces on a dev box long before the next release.