### PR TITLE
Add support for upstream SSL

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,5 @@
-SSL_TYPE=selfsign|letsencrypt|customssl
+SSL_TYPE=selfsign|letsencrypt|customssl|upstream
 DOMAIN=local|your.domain.com
 SYSADMIN_EMAIL=administrator@email.com
+HTTP_PORT=80
+HTTPS_PORT=443

--- a/.env
+++ b/.env
@@ -1,5 +1,0 @@
-SSL_TYPE=selfsign|letsencrypt|customssl|upstream
-DOMAIN=local|your.domain.com
-SYSADMIN_EMAIL=administrator@email.com
-HTTP_PORT=80
-HTTPS_PORT=443

--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,12 @@
+# Use fully qualified domain names. Set to DOMAIN=local if SSL_TYPE=selfsign.
+DOMAIN=your.domain.com
+
+# Used for Let's Encrypt expiration emails and Enketo technical support emails
+SYSADMIN_EMAIL=administrator@email.com
+
+# Options: letsencrypt, customssl, upstream, selfsign
+SSL_TYPE=letsencrypt
+
+# Do not change if using SSL_TYPE=letsencrypt
+HTTP_PORT=80
+HTTPS_PORT=443

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,12 +47,13 @@ services:
       - service
       - enketo
     environment:
-      - SSL_TYPE=${SSL_TYPE}
+      - SSL_TYPE=${SSL_TYPE:-letsencrypt}
       - DOMAIN=${DOMAIN}
       - CERTBOT_EMAIL=${SYSADMIN_EMAIL}
     ports:
-      - "80:80"
-      - "443:443"
+      - "${HTTP_PORT:-80}:80"
+      - "${HTTPS_PORT:-443}:443"
+
     healthcheck:
       test: [ "CMD-SHELL", "nc -z localhost 443 || exit 1" ]
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       - "${HTTPS_PORT:-443}:443"
 
     healthcheck:
-      test: [ "CMD-SHELL", "nc -z localhost 443 || exit 1" ]
+      test: [ "CMD-SHELL", "nc -z localhost 80 || exit 1" ]
     restart: always
 
   pyxform:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,6 @@ services:
     environment:
       - MAILNAME=${DOMAIN}
     restart: always
-
   service:
     container_name: service
     build:
@@ -53,16 +52,13 @@ services:
     ports:
       - "${HTTP_PORT:-80}:80"
       - "${HTTPS_PORT:-443}:443"
-
     healthcheck:
       test: [ "CMD-SHELL", "nc -z localhost 80 || exit 1" ]
     restart: always
-
   pyxform:
     container_name: pyxform
     image: 'getodk/pyxform-http:v1.3.4'
     restart: always
-
   secrets:
     container_name: secrets
     volumes:
@@ -106,10 +102,8 @@ services:
       - redis-server
       - /usr/local/etc/redis/redis.conf
     restart: always
-
 volumes:
   transfer:
   enketo_redis_main:
   enketo_redis_cache:
   secrets:
-

--- a/files/nginx/odk-setup.sh
+++ b/files/nginx/odk-setup.sh
@@ -1,5 +1,5 @@
 DHPATH=/etc/dh/nginx.pem
-if [ ! -e "$DHPATH" ]
+if [ ! -e "$DHPATH" ] && [ "$SSL_TYPE" != "upstream" ]
 then
   echo "diffie hellman private key does not exist; creating.."
   openssl dhparam -out "$DHPATH" 2048
@@ -25,6 +25,13 @@ if [ "$SSL_TYPE" = "letsencrypt" ]
 then
   echo "starting nginx with certbot.."
   /bin/bash /scripts/entrypoint.sh
+elif [ "$SSL_TYPE" = "upstream" ]
+then
+  perl -i -ne 's/listen 443.*/listen 80;/; print if ! /ssl_/' /etc/nginx/conf.d/odk.conf
+  perl -i -pe 's/X-Forwarded-Proto \$scheme/X-Forwarded-Proto https/;' /etc/nginx/conf.d/odk.conf
+  rm -f /etc/nginx/conf.d/certbot.conf
+  echo "starting nginx without local SSL to allow for upstream SSL.."
+  nginx -g "daemon off;"
 else
   echo "starting nginx without certbot.."
   nginx -g "daemon off;"


### PR DESCRIPTION
This builds on the PR at https://github.com/getodk/central/pull/182 from @aiqui. Fixes #213.

It'd be nice to have this functionality for ODK Cloud so we can manage SSL at the load balancer rather than within nginx.

Changes
* I don't love hiding variables from people, so instead of `none`, which suggests to people that they don't need SSL, I call it `upstream`. Open to changing the name and open to hiding it.
* Updated output message to reflect the above

Additional, unrelated change:
* Moved variables to .env.template to make it easier to evolve without triggering merge conflicts. I believe this will not delete existing .env files that have changes, but I haven't verified this.