### PR TITLE
ops: allow for multiple instances

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,12 +23,12 @@ jobs:
           command: |
             set -x
             docker-compose up -d
-            docker run --network container:nginx \
+            CONTAINER_NAME=$(docker inspect -f '{{.Name}}' $(docker-compose ps -q nginx) | cut -c2-)
+            docker run --network container:$CONTAINER_NAME \
               appropriate/curl -4 --insecure --retry 30 --retry-delay 10 --retry-connrefused https://localhost/ \
               | tee /dev/tty \
               | grep -q 'ODK Central'
-            docker run --network container:nginx \
+            docker run --network container:$CONTAINER_NAME \
               appropriate/curl -4 --insecure --retry 20 --retry-delay 2 --retry-connrefused https://localhost/v1/projects \
               | tee /dev/tty \
               | grep -q '\[\]'
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
       POSTGRES_DATABASE: odk
     restart: always
   mail:
-    container_name: mail
     image: "itsissa/namshi-smtp:4.89-2.deb9u5"
     volumes:
       - ./files/dkim/config:/etc/exim4/_docker_additional_macros:ro
@@ -19,7 +18,6 @@ services:
       - MAILNAME=${DOMAIN}
     restart: always
   service:
-    container_name: service
     build:
       context: .
       dockerfile: service.dockerfile
@@ -38,7 +36,6 @@ services:
     command: [ "./wait-for-it.sh", "postgres:5432", "--", "./start-odk.sh" ]
     restart: always
   nginx:
-    container_name: nginx
     build:
       context: .
       dockerfile: nginx.dockerfile
@@ -56,11 +53,9 @@ services:
       test: [ "CMD-SHELL", "nc -z localhost 80 || exit 1" ]
     restart: always
   pyxform:
-    container_name: pyxform
     image: 'getodk/pyxform-http:v1.5.0'
     restart: always
   secrets:
-    container_name: secrets
     volumes:
       - secrets:/etc/secrets
     build:
@@ -68,7 +63,6 @@ services:
       dockerfile: secrets.dockerfile
     command: './generate-secrets.sh'
   enketo:
-    container_name: enketo
     volumes:
       - secrets:/etc/secrets
     build:
@@ -84,7 +78,6 @@ services:
       - SUPPORT_EMAIL=${SYSADMIN_EMAIL}
   enketo_redis_main:
     image: redis:5
-    container_name: enketo_redis_main
     volumes:
       - ./files/enketo/redis-enketo-main.conf:/usr/local/etc/redis/redis.conf:ro
       - enketo_redis_main:/data
@@ -94,7 +87,6 @@ services:
     restart: always
   enketo_redis_cache:
     image: redis:5
-    container_name: enketo_redis_cache
     volumes:
       - ./files/enketo/redis-enketo-cache.conf:/usr/local/etc/redis/redis.conf:ro
       - enketo_redis_cache:/data


### PR DESCRIPTION
The use of [container_name](https://docs.docker.com/compose/compose-file/compose-file-v3/#container_name) means that you can't run multiple instances of Central on the same machine. 

It also means you can't ever have a container called mail or service or secrets. Removing the container name solves this problem because Docker automatically prepends the folder name to the container (e.g., service becomes central_service_1). This happens with our PostgreSQL container already since it doesn't have a container_name.

- [x]  I have confirmed that you can upgrade existing installs of Central with this change and it loads just fine. 
- [x] I have confirmed that after upgrade, Enketo (which uses host-name based addressing) works by launching a preview. This is because Docker uses the service name to reach containers. 
- [x] I have confirmed that I can run multiple copies of Central on the same machine and they both load.

This isn't a must have change, so if it feels high risk, I'm open to waiting until after v1.2