### PR TITLE
Changed main readme to mention Enketo in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ We would love your contributions to Central. If you have thoughts or suggestions
 In addition to the Backend and the Frontend, Central deploys services:
 
 * Central relies on [pyxform-http](https://github.com/getodk/pyxform-http) for converting forms from XLSForm. It generally shouldn't be needed in development but can be run locally.
-* Central relies on [Enketo](https://github.com/enketo/enketo-express) for web form functionality. Neither the Backend nor the Frontend are configured to work with Enketo in development. Instead, you can drive local development that integrates with Enketo using tests and then try new functionality in a [production environment](https://docs.getodk.org/central-install-digital-ocean/) by [checking out a commit](https://docs.getodk.org/central-upgrade/) from your fork. Be sure to follow the upgrade instructions exactly. In particular, do not run `docker-compose down` because this will recreate new volumes instead of using existing ones.
+* Central relies on [Enketo](https://github.com/enketo/enketo-express) for web form functionality. Enketo can be run locally and configured to work with Frontend and Backend in development by following these [instructions](https://github.com/getodk/central-frontend/blob/master/docs/enketo.md).
 
 Operations
 ==========


### PR DESCRIPTION
In response to to https://github.com/getodk/central-frontend/pull/467#issuecomment-857769473, further addresses issue #219.

I took out the bit about testing enketo by checking out a specific fork in production because it's not necessary anymore and seems like a challenging way to do enketo-related development.

But one argument for keeping it is that maybe that nugget of information isn't well-captured somewhere else? Ehh.. what nugget am I talking about? The nugget of checking out a specific commit and following the [upgrade instructions](https://docs.getodk.org/central-upgrade/) while not running `docker-compose down`.