### PR TITLE
Enable local driver for log rotation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,8 @@ services:
       - SYSADMIN_EMAIL=${SYSADMIN_EMAIL}
     command: [ "./wait-for-it.sh", "postgres:5432", "--", "./start-odk.sh" ]
     restart: always
+    logging:
+      driver: local
   nginx:
     build:
       context: .
@@ -52,6 +54,10 @@ services:
     healthcheck:
       test: [ "CMD-SHELL", "nc -z localhost 80 || exit 1" ]
     restart: always
+    logging:
+      driver: local
+      options:
+        max-file: "30"
   pyxform:
     image: 'getodk/pyxform-http:v1.5.1'
     restart: always


### PR DESCRIPTION
Closes #231. For this PR, I verified that on the QA server...
* `docker-compose logs service` outputs logs
* `sudo docker ps -qa | sudo xargs docker inspect --format='{{.LogPath}}' | sudo xargs ls -hl` shows a reduction in log size
* `docker inspect <container>` shows max-file as a config

As detailed at https://docs.docker.com/config/containers/logging/local/#options, this defaults to a 20M file for each log and 5 maximum files (each compressed). 

In a 3 month period, we [expect 15MB for service and 640MB for nginx](https://github.com/getodk/central/issues/231#issuecomment-910864302) for a very active server, so the defaults for 100MB for service (because it's less stuff in docker-compose) and 600MB for nginx seem like good conservative defaults. We can dial the latter down if necessary.

This risk of this PR is that we are possibly throwing away old logs and someone might find that objectionable.