### PR TITLE
Prevent exploitable TLS v1.0 and cross-frame scripting

### DIFF
--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -4,13 +4,17 @@ server {
   ssl_certificate_key /etc/${SSL_TYPE}/live/${CNAME}/privkey.pem;
   ssl_trusted_certificate /etc/${SSL_TYPE}/live/${CNAME}/fullchain.pem;
 
-  ssl_protocols TLSv1.2 TLSv1.1 TLSv1;
-  ssl_prefer_server_ciphers on;
-  ssl_ciphers "EECDH+ECDSA+AESGCM EECDH+aRSA+AESGCM EECDH+ECDSA+SHA384 EECDH+ECDSA+SHA256 EECDH+aRSA+SHA384 EECDH+aRSA+SHA256 EECDH+aRSA+RC4 EECDH EDH+aRSA RC4 !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS";
+  # https://ssl-config.mozilla.org/#server=nginx&version=1.17.7&config=intermediate&openssl=1.1.1d&guideline=5.6
+  ssl_protocols TLSv1.2 TLSv1.3;
+  ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+  ssl_prefer_server_ciphers off;
+
   ssl_dhparam /etc/dh/nginx.pem;
 
   server_tokens off;
-  add_header Strict-Transport-Security "max-age=31536000";
+  add_header Strict-Transport-Security "max-age=63072000" always;
+
+  add_header X-Frame-Options "SAMEORIGIN";
   add_header X-Content-Type-Options nosniff;
 
   client_max_body_size 100m;


### PR DESCRIPTION
Per @issa-tseng's guidance, I tried to do the most narrow change from our pen test. 

The slightly controversial change is increasing the Strict-Transport-Security age and adding always. The age matches the [Moz guide](https://ssl-config.mozilla.org/#server=nginx&version=1.17.7&config=intermediate&openssl=1.1.1d&guideline=5.60) instead of the [Nginx guide](https://www.nginx.com/blog/http-strict-transport-security-hsts-and-nginx/), but I don't think we've done anything dangerous.

Things I tried to verify.
* https://www.ssllabs.com/ssltest/analyze.html?d=dev.getodk.cloud reports the server has TLS 1.3
* https://gf.dev/x-frame-options-test says we prevent click-jacking.
* Enketo logged in submissions and edits work
* Enketo public access links work
* Collect submissions work

