### PR TITLE
Add Cache-Control header for /version.txt and /index.html

### DIFF
--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -49,6 +49,13 @@ server {
 
   location / {
     root /usr/share/nginx/html;
+
+    location /version.txt {
+      add_header Cache-Control no-cache;
+    }
+    location /index.html {
+      add_header Cache-Control no-cache;
+    }
   }
 }
 


### PR DESCRIPTION
This commit aims to prevent excessive caching of /version.txt and /index.html.

Prior to this commit, I noticed the following behavior:

  - Open Frontend in a browser.
  - Change the source, then rebuild. This will change /version.txt.
  - However, if you click on the Version link in the help dropdown, the old /version.txt is shown in a new tab.
  - Only if you refresh the new tab is the new /version.txt shown.

getodk/central-frontend#496 only works if requesting /version.txt returns the current version, reflecting any change.

Adding the `Cache-Control` header for /version.txt seems to resolve this issue. I also added it for /index.html, which should make it unnecessary to ever force-refresh /index.html in a browser.

I think `Cache-Control` is useful for these two files, but I don't think that it is useful for other files:

  - CSS and JS files from Vue will have a hash in their filenames that will change as the associated source changes.
  - We use a query string for cache-busting when requesting icon files.