### PR TITLE
Add tag of central repo to version.txt

### DIFF
--- a/files/prebuild/write-version.sh
+++ b/files/prebuild/write-version.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-{ echo "versions:"; git rev-parse HEAD; git submodule; } > /tmp/version.txt
+{ echo "versions:"; echo "$(git rev-parse HEAD) ($(git describe --tags))"; git submodule; } > /tmp/version.txt
 


### PR DESCRIPTION
Right now version.txt shows the commit hashes of `central`, `central-backend`, and `central-frontend`. For `central-backend` and `central-frontend`, it also shows the latest tag. With this PR, version.txt will also show a tag for `central`.

This change is most useful after a patch release that has only changed `central`. For example, right now the latest release is v1.3.1, but version.txt only shows v1.3.0:

```
versions:
d5d430ae204001d23528e092d56b0586e4512394
 681f56713d5f9d4541b066b31e7a36efb0f7bfef client (v1.3.0)
 61b1848ba169eb455477ebeb79f0ea745e6eb478 server (v1.3.0)
```

The hash alone is enough to confirm that `central` is on the right commit, but it'd be nice to be able to see the version at a glance. With this PR, version.txt would show the relationship between the current commit to `central` and the latest tag, in the same way as what's shown for `central-backend` and `central-frontend`:

```
versions:
d5d430ae204001d23528e092d56b0586e4512394 (v1.3.1-2-gd5d430a)
 681f56713d5f9d4541b066b31e7a36efb0f7bfef client (v1.3.0)
 61b1848ba169eb455477ebeb79f0ea745e6eb478 server (v1.3.0)
```