### PR TITLE
Upgrade Enketo and pyxform

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
       options:
         max-file: "30"
   pyxform:
-    image: 'ghcr.io/getodk/pyxform-http:v1.6.0'
+    image: 'ghcr.io/getodk/pyxform-http:v1.7.0'
     restart: always
   secrets:
     volumes:

--- a/enketo.dockerfile
+++ b/enketo.dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/enketo/enketo-express:3.0.1
+FROM ghcr.io/enketo/enketo-express:3.0.3
 
 ENV ENKETO_SRC_DIR=/srv/src/enketo_express
 WORKDIR ${ENKETO_SRC_DIR}


### PR DESCRIPTION
Changes...
- Forms can use `allow-mock-accuracy` parameter to allow external GPS to report accuracy
- New browser submissions with defaults in URL query string are now accepted
- Media files with spaces in their filename now load in browser
- Form loading in Firefox's private browsing mode now works
