### PR TITLE
Proposal: Pre-Build images in Github

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,8 +10,6 @@ on:
     branches: [ master ]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
-  pull_request:
-    branches: [ master ]
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,7 +19,6 @@ env:
 jobs:
 
   build-secrets:
-    #needs: checkout_meta
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -44,7 +43,6 @@ jobs:
           # generate Docker tags based on the following events/attributes
           tags: |
             type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}.{{hotfix}}
             type=semver,pattern={{major}}.{{minor}}
@@ -85,7 +83,6 @@ jobs:
           # generate Docker tags based on the following events/attributes
           tags: |
             type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}.{{hotfix}}
             type=semver,pattern={{major}}.{{minor}}
@@ -126,7 +123,6 @@ jobs:
           # generate Docker tags based on the following events/attributes
           tags: |
             type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}.{{hotfix}}
             type=semver,pattern={{major}}.{{minor}}
@@ -168,7 +164,6 @@ jobs:
           # generate Docker tags based on the following events/attributes
           tags: |
             type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}.{{hotfix}}
             type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,186 @@
+name: Docker
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  push:
+    branches: [ master ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  REGISTRY: ghcr.io
+  REGISTRY_WITH_PATH: ghcr.io/${{ github.repository_owner }}
+
+
+jobs:
+
+  build-secrets:
+    #needs: checkout_meta
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Checkout submodules
+        run: git submodule update -i
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY_WITH_PATH }}/secrets
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}.{{hotfix}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+      - name: Build and push secrets Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          file: secrets.dockerfile
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build-nginx:
+    #needs: checkout_meta
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Checkout submodules
+        run: git submodule update -i
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY_WITH_PATH }}/nginx
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}.{{hotfix}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+      - name: Build and push nginx Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          file: nginx.dockerfile
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build-service:
+    #needs: checkout_meta
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Checkout submodules
+        run: git submodule update -i
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY_WITH_PATH }}/service
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}.{{hotfix}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+      - name: Build and push service Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          file: service.dockerfile
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+
+  build-enketo:
+    #needs: checkout_meta
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Checkout submodules
+        run: git submodule update -i
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY_WITH_PATH }}/enketo
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}.{{hotfix}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+      - name: Build and push enketo Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          file: enketo.dockerfile
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   postgres:
     image: "postgres:9.6"
     volumes:
-      - /var/lib/postgresql/data
+      - ./volumes/postgres:/var/lib/postgresql/data
     environment:
       POSTGRES_USER: odk
       POSTGRES_PASSWORD: odk
@@ -18,9 +18,7 @@ services:
       - MAILNAME=${DOMAIN}
     restart: always
   service:
-    build:
-      context: .
-      dockerfile: service.dockerfile
+    image: ghcr.io/mattelacchiato/service:latest
     depends_on:
       - secrets
       - postgres
@@ -28,19 +26,19 @@ services:
       - pyxform
       - enketo
     volumes:
-      - secrets:/etc/secrets
+      - ./volumes/secrets:/etc/secrets
       - /data/transfer:/data/transfer
+      - ./files/service/config.json.template:/usr/share/odk/config.json.template
     environment:
-      - DOMAIN=${DOMAIN}
-      - SYSADMIN_EMAIL=${SYSADMIN_EMAIL}
+      - DOMAIN
+      - SYSADMIN_EMAIL
+      - ENKETO_API_KEY
     command: [ "./wait-for-it.sh", "postgres:5432", "--", "./start-odk.sh" ]
     restart: always
     logging:
       driver: local
   nginx:
-    build:
-      context: .
-      dockerfile: nginx.dockerfile
+    image: ghcr.io/mattelacchiato/nginx:latest
     depends_on:
       - service
       - enketo
@@ -62,31 +60,27 @@ services:
     image: 'ghcr.io/getodk/pyxform-http:v1.7.0'
     restart: always
   secrets:
+    image: ghcr.io/mattelacchiato/secrets:latest
     volumes:
-      - secrets:/etc/secrets
-    build:
-      context: .
-      dockerfile: secrets.dockerfile
+      - ./volumes/secrets:/etc/secrets
     command: './generate-secrets.sh'
   enketo:
+    image: ghcr.io/mattelacchiato/enketo:latest
     volumes:
-      - secrets:/etc/secrets
-    build:
-      context: .
-      dockerfile: enketo.dockerfile
+      - ./volumes/secrets:/etc/secrets
     restart: always
     depends_on:
       - secrets
       - enketo_redis_main
       - enketo_redis_cache
     environment:
-      - DOMAIN=${DOMAIN}
+      - DOMAIN
       - SUPPORT_EMAIL=${SYSADMIN_EMAIL}
   enketo_redis_main:
     image: redis:5
     volumes:
       - ./files/enketo/redis-enketo-main.conf:/usr/local/etc/redis/redis.conf:ro
-      - enketo_redis_main:/data
+      - ./volumes/redis/main:/data
     command:
       - redis-server
       - /usr/local/etc/redis/redis.conf
@@ -95,13 +89,8 @@ services:
     image: redis:5
     volumes:
       - ./files/enketo/redis-enketo-cache.conf:/usr/local/etc/redis/redis.conf:ro
-      - enketo_redis_cache:/data
+      - ./volumes/redis/cache:/data
     command:
       - redis-server
       - /usr/local/etc/redis/redis.conf
     restart: always
-volumes:
-  transfer:
-  enketo_redis_main:
-  enketo_redis_cache:
-  secrets:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   postgres:
     image: "postgres:9.6"
     volumes:
-      - ./volumes/postgres:/var/lib/postgresql/data
+      - /var/lib/postgresql/data
     environment:
       POSTGRES_USER: odk
       POSTGRES_PASSWORD: odk
@@ -26,7 +26,7 @@ services:
       - pyxform
       - enketo
     volumes:
-      - ./volumes/secrets:/etc/secrets
+      - secrets:/etc/secrets
       - /data/transfer:/data/transfer
       - ./files/service/config.json.template:/usr/share/odk/config.json.template
     environment:
@@ -62,12 +62,12 @@ services:
   secrets:
     image: ghcr.io/mattelacchiato/secrets:latest
     volumes:
-      - ./volumes/secrets:/etc/secrets
+      - secrets:/etc/secrets
     command: './generate-secrets.sh'
   enketo:
     image: ghcr.io/mattelacchiato/enketo:latest
     volumes:
-      - ./volumes/secrets:/etc/secrets
+      - secrets:/etc/secrets
     restart: always
     depends_on:
       - secrets
@@ -80,7 +80,7 @@ services:
     image: redis:5
     volumes:
       - ./files/enketo/redis-enketo-main.conf:/usr/local/etc/redis/redis.conf:ro
-      - ./volumes/redis/main:/data
+      - enketo_redis_main:/data
     command:
       - redis-server
       - /usr/local/etc/redis/redis.conf
@@ -89,8 +89,13 @@ services:
     image: redis:5
     volumes:
       - ./files/enketo/redis-enketo-cache.conf:/usr/local/etc/redis/redis.conf:ro
-      - ./volumes/redis/cache:/data
+      - enketo_redis_cache:/data
     command:
       - redis-server
       - /usr/local/etc/redis/redis.conf
     restart: always
+volumes:
+  transfer:
+  enketo_redis_main:
+  enketo_redis_cache:
+  secrets:

--- a/files/enketo/generate-secrets.sh
+++ b/files/enketo/generate-secrets.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 
 if [ ! -f /etc/secrets/enketo-secret ]; then
   LC_ALL=C tr -dc '[:alnum:]' < /dev/urandom | head -c64 > /etc/secrets/enketo-secret

--- a/secrets.dockerfile
+++ b/secrets.dockerfile
@@ -1,2 +1,2 @@
-FROM node:12.6.0
+FROM alpine
 COPY files/enketo/generate-secrets.sh ./

--- a/service.dockerfile
+++ b/service.dockerfile
@@ -17,7 +17,6 @@ COPY server/ ./
 COPY files/service/scripts/ ./
 COPY files/service/pm2.config.js ./
 
-COPY files/service/config.json.template /usr/share/odk/
 COPY files/service/odk-cmd /usr/bin/
 
 EXPOSE 8383


### PR DESCRIPTION
This is a proposal as requested by @yanokwa at
https://forum.getodk.org/t/host-odk-central-docker-images-on-github-container-registry/29812/19?u=mattelacchiato

It introduces the usage of Github actions to build the docker images in
Github and host them at ghcr.io (the github package repository). For
open source projects, the infrastructure is for free.

Additionally, I've removed the unnamed volumes from the
docker-compose.yml. The reason is that unnamed volumes are hard to
backup. Currently, the enketo secrets are not part of the backup, which
is really bad if you have to recover your installation and all public
links are not working anymore for submitters.

For the same aspect of easier backup on OS-level, I moved the postgres
and redis folder to a local volume, too.

I switch the secrets docker base image from node to alpine, which is
much more lightweight. We don't need node for a simple bash script
execution.

This setup will increase the benefits for experienced administrators
without removing any convenience for beginners.