### PR TITLE
Fix LetsEncrypt renewal failures

### DIFF
--- a/files/nginx/certbot.conf
+++ b/files/nginx/certbot.conf
@@ -1,0 +1,13 @@
+server {
+    # Listen only on port 81 for localhost, and nothing else.
+    server_name 127.0.0.1;
+    listen 127.0.0.1:81 default_server;
+
+    charset utf-8;
+
+    # Certbot's folder used for the ACME challenge response.
+    location ^~ /.well-known/acme-challenge {
+        default_type text/plain;
+        root /var/www/letsencrypt;
+    }
+}

--- a/files/nginx/odk-setup.sh
+++ b/files/nginx/odk-setup.sh
@@ -24,16 +24,20 @@ CNAME=$([ "$SSL_TYPE" = "customssl" ] && echo "local" || echo "$DOMAIN") \
 if [ "$SSL_TYPE" = "letsencrypt" ]
 then
   echo "starting nginx with certbot.."
+  cp /usr/share/nginx/certbot.conf /etc/nginx/conf.d/certbot.conf
+  cp /usr/share/nginx/redirector.conf /etc/nginx/conf.d/redirector.conf
   /bin/bash /scripts/start_nginx_certbot.sh
 elif [ "$SSL_TYPE" = "upstream" ]
 then
+  echo "starting nginx without local SSL to allow for upstream SSL.."
   perl -i -ne 's/listen 443.*/listen 80;/; print if ! /ssl_/' /etc/nginx/conf.d/odk.conf
   perl -i -pe 's/X-Forwarded-Proto \$scheme/X-Forwarded-Proto https/;' /etc/nginx/conf.d/odk.conf
   rm -f /etc/nginx/conf.d/certbot.conf
-  echo "starting nginx without local SSL to allow for upstream SSL.."
+  rm -f /etc/nginx/conf.d/redirector.conf
   nginx -g "daemon off;"
 else
   echo "starting nginx without certbot.."
+  rm -f /etc/nginx/conf.d/certbot.conf
+  rm -f /etc/nginx/conf.d/redirector.conf
   nginx -g "daemon off;"
 fi
-

--- a/files/nginx/redirector.conf
+++ b/files/nginx/redirector.conf
@@ -1,0 +1,19 @@
+server {
+    # Listen on plain old HTTP and catch all requests so they can be redirected
+    # to HTTPS instead.
+    listen 80 default_server reuseport;
+    listen [::]:80 default_server reuseport;
+
+    # Pass this particular URL off to the certbot server so it can properly
+    # respond to the Let's Encrypt ACME challenges for the HTTPS certificates.
+    location '/.well-known/acme-challenge' {
+        default_type "text/plain";
+        proxy_pass http://localhost:81;
+    }
+
+    # Everything else gets shunted over to HTTPS for each user defined
+    # server to handle.
+    location / {
+        return 301 https://$http_host$request_uri;
+    }
+}

--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -4,8 +4,8 @@ COPY ./ ./
 RUN files/prebuild/write-version.sh
 RUN files/prebuild/build-frontend.sh
 
-
-FROM jonasal/nginx-certbot:2.4
+# make sure you have updated *.conf files when upgrading this
+FROM jonasal/nginx-certbot:2.4.1
 
 EXPOSE 80
 EXPOSE 443
@@ -15,14 +15,15 @@ ENTRYPOINT [ "/bin/bash", "/scripts/odk-setup.sh" ]
 
 RUN apt-get update; apt-get install -y openssl netcat nginx-extras lua-zlib
 
-RUN mkdir -p /etc/selfsign/live/local
-COPY files/nginx/odk-setup.sh /scripts
+RUN mkdir -p /etc/selfsign/live/local/
+COPY files/nginx/odk-setup.sh /scripts/
 
 COPY files/local/customssl/*.pem /etc/customssl/live/local/
 
 COPY files/nginx/default /etc/nginx/sites-enabled/
-COPY files/nginx/inflate_body.lua /usr/share/nginx
-COPY files/nginx/odk.conf.template /usr/share/nginx
-COPY --from=intermediate client/dist/ /usr/share/nginx/html
+COPY files/nginx/inflate_body.lua /usr/share/nginx/
+COPY files/nginx/odk.conf.template /usr/share/nginx/
+COPY files/nginx/certbot.conf /usr/share/nginx/
+COPY files/nginx/redirector.conf /usr/share/nginx/
+COPY --from=intermediate client/dist/ /usr/share/nginx/html/
 COPY --from=intermediate /tmp/version.txt /usr/share/nginx/html/
-


### PR DESCRIPTION
Central certs were not able to renew because some of them had the old conf from https://github.com/staticfloat/docker-nginx-certbot/tree/master/src/nginx_conf.d. Instead we need the conf from https://github.com/JonasAlfredsson/docker-nginx-certbot/tree/master/src/nginx_conf.d.

I tried a million ways in the Dockerfile to copy the *.conf files into /etc/nginx/conf.d, but they'd would never appear in the live container, so I reverted to using odk-setup.sh.

My specific changes are...
* Pin docker-nginx-certbot version to 2.4.1 not 2.4 because we don't want any surprises if they release a patch.
* Put the necessary files from https://github.com/JonasAlfredsson/docker-nginx-certbot/tree/master/src/nginx_conf.d into repo and copy to /usr/share/nginx/. This does mean that each time we update docker-nginx-certbot, we should also upgrade the conf files.
* In odk-setup.sh, copy the conf files into /etc/nginx/conf.d/ 
* Remove all certbot conf files when using configurations that don't involve certbot
   * This seems like the highest risk change, but it should only affect a tiny group of people there's a bug 
* Add trailing slashes to folders to make it clearer what each command is doing
* Move around echo message so it's more consistent

I verified this worked with ODK Cloud setups (letsencrypt), but I did not verify with upstream, selfsigned, or nothing.