### PR TITLE
Downgrade node to fix stream closing

### DIFF
--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.17.6 as intermediate
+FROM node:12.22.7 as intermediate
 
 COPY ./ ./
 RUN files/prebuild/write-version.sh

--- a/service.dockerfile
+++ b/service.dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.17.6
+FROM node:12.22.7
 
 WORKDIR /usr/odk
 


### PR DESCRIPTION
Tried this PR on a few servers and those servers don't report the premature close errors we've seen.

I changed node in the intermediate nginx build as well to reduce the number of node containers on the host machine.