### PR TITLE
Enketo can now load config at runtime, so rebuilding is not needed

### DIFF
--- a/enketo.dockerfile
+++ b/enketo.dockerfile
@@ -16,10 +16,6 @@ COPY files/enketo/start-enketo.sh ${ENKETO_SRC_DIR}/start-enketo.sh
 
 RUN apt-get update; apt-get install gettext-base
 
-RUN npm install
-RUN grunt
-RUN npm prune --production
-
 EXPOSE 8005
 
 CMD ./start-enketo.sh


### PR DESCRIPTION
Thanks to https://github.com/enketo/enketo-express/issues/163, Enketo can load its config at run time, so we no longer need to run npm and grunt.

I verified this change works by: 
1. Starting from a fresh install from this PR and confirming that form previews and public access links work.
2. Starting from a fresh Central v1.3.3 install, applying this PR, and confirming that old and new form previews and public access links work.