### PR TITLE
Upgrade to CI to Ubuntu 20 LTS because Ubuntu 16 is EOL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202201-02
 
     steps:
       - checkout


### PR DESCRIPTION
From CircleCI...

> We are deprecating Ubuntu 16.04-based machine images on CircleCI in preparation for an EOL on Tuesday, May 31, 2022 to ensure your builds remain secure. For a detailed overview of how this will affect your workflow, [read the blog article here](https://circleci.com/blog/ubuntu-14-16-image-deprecation).
> 
> We will also be conducting temporary brownouts on Tuesday, March 29, 2022, and again on Tuesday, April 26, 2022 during which these images will be unavailable.
> 
> We are contacting you because one or more of your projects has a job that uses an Ubuntu 16.04-based image.
> 
> The project(s) using an image based on Ubuntu 16.04 are:
> [central]
> 
> If you have specified an Ubuntu 16.04-based image please see our [migration guide](https://circleci.com/docs/2.0/images/linux-vm/16.04-to-20.04-migration/) to upgrade to a newer version of Ubuntu image in order to avoid any service disruption during the brownout & subsequent EOL.
> 
> We will also be releasing a CircleCI Ubuntu 22.04 image on April 22nd offering the flexibility to upgrade to the latest LTS version of Ubuntu image before we remove older versions permanently. A beta version of the image will be available March 21st.
> 
> Our team is committed to getting you the most performant builds while maintaining security.

This PR is for the most [recent Ubuntu LTS published by CircleCI](https://discuss.circleci.com/t/linux-machine-executor-images-2022-january-q1-update/42831).

This PR is low risk, but we should probably wait until after the release, and any hot fixes, are out.