### PR TITLE
Switch from GA to Fathom

### DIFF
--- a/docs/news.html
+++ b/docs/news.html
@@ -4,14 +4,7 @@
     <meta charset="utf-8">
     <title>ODK Central</title>
     <link rel="stylesheet" href="style.css">
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-91951913-7"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'UA-91951913-7', { cookie_flags: 'SameSite=None;Secure' });
-    </script>
+    <script src="https://thirtyfive-england.getodk.org/script.js" data-site="PBSTMJFG" defer></script>
   </head>
   <body>
     <div class="news-item">


### PR DESCRIPTION
Austria and France have both ruled that GA is not GDPR compliant. Fathom is.

I've deployed it on getodk.org, forum.getodk.org, docs.getodk.org, and xlsform.getodk.org so far and it's working great. 

No cookies are required so I think cross-site issues. That said, it'd be good if someone could confirm that this won't throw up any cross-site errors in Central.