### PR TITLE
Bug #258: Don't run server if database migrations fail

### DIFF
--- a/files/service/scripts/start-odk.sh
+++ b/files/service/scripts/start-odk.sh
@@ -9,7 +9,8 @@ echo "checking migration success.."
 node -e 'const { withDatabase, checkMigrations } = require("./lib/model/migrate"); withDatabase(require("config").get("default.database"))(checkMigrations);'
 
 if [ $? -eq 1 ]; then
-  echo "migration error: there are still pending migrations... central will not run until fixed"
+  echo "*** Error starting ODK! ***"
+  echo "After attempting to automatically migrate the database, we have detected unapplied migrations, which suggests a problem with the database migration step. Please look in the console above this message for any errors and post what you find in the forum: https://forum.getodk.org/"
   exit 1
 fi
 

--- a/files/service/scripts/start-odk.sh
+++ b/files/service/scripts/start-odk.sh
@@ -5,6 +5,14 @@ echo "generating local service configuration.."
 echo "running migrations.."
 node -e 'const { withDatabase, migrate } = require("./lib/model/migrate"); withDatabase(require("config").get("default.database"))(migrate);'
 
+echo "checking migration success.."
+node -e 'const { withDatabase, checkMigrations } = require("./lib/model/migrate"); withDatabase(require("config").get("default.database"))(checkMigrations);'
+
+if [ $? -eq 1 ]; then
+  echo "migration error: there are still pending migrations... central will not run until fixed"
+  exit 1
+fi
+
 echo "starting cron.."
 cron -f &
 


### PR DESCRIPTION
Using a new helper function from central-backend (https://github.com/getodk/central-backend/pull/462) check for any pending migrations and exit the startup script if there are any.

The existence of pending migrations (after they should have run automatically) indicates there was likely an error with the migrations, and the cron jobs and server should not run with the database in an erroneous state. 

Fixes #258 