### PR TITLE
Add support for SSL running on different ports upstream

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -10,3 +10,6 @@ SSL_TYPE=letsencrypt
 # Do not change if using SSL_TYPE=letsencrypt
 HTTP_PORT=80
 HTTPS_PORT=443
+
+# Do not change unless using SSL_TYPE=upstream
+UPSTREAM_HTTPS_PORT=443

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - /data/transfer:/data/transfer
     environment:
       - DOMAIN=${DOMAIN}
-      - HTTPS_PORT=${HTTPS_PORT:-443}
+      - HTTPS_PORT=${UPSTREAM_HTTPS_PORT:-443}
       - SYSADMIN_EMAIL=${SYSADMIN_EMAIL}
     command: [ "./wait-for-it.sh", "postgres:5432", "--", "./start-odk.sh" ]
     restart: always
@@ -83,7 +83,7 @@ services:
     environment:
       - DOMAIN=${DOMAIN}
       - SUPPORT_EMAIL=${SYSADMIN_EMAIL}
-      - HTTPS_PORT=${HTTPS_PORT:-443}
+      - HTTPS_PORT=${UPSTREAM_HTTPS_PORT:-443}
   enketo_redis_main:
     image: redis:5
     volumes:


### PR DESCRIPTION
I don't think this should be merged, but I want to show my preferred alternative to https://github.com/getodk/central/pull/291/files. 

I think perhaps what we should do is add docs for people to edit their .env and docker-compose to match what is in this PR, and warn them that it's subject to change. This way, most users don't have to change anything.

I've confirmed that with an upstream server, web forms with previews (including with images) works. I've also confirmed that  web submissions work and password resets show the correct port.

Truth be told, I regret allowing port customization and upstream servers to begin with. It's too fragile.