### PR TITLE
pm2: remove duplicate logging

### DIFF
--- a/files/service/pm2.config.js
+++ b/files/service/pm2.config.js
@@ -6,10 +6,6 @@ module.exports = {
     // the default is 1600ms; we aren't that impatient:
     kill_timeout: 30000,
 
-    // log to stdout/stderr:
-    out_file: '/proc/1/fd/1',
-    error_file: '/proc/1/fd/2',
-
     // per Unitech/pm2#2045 this resolves a conflict w node-config:
     instance_var: 'INSTANCE_ID'
   }]


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/265?

This change seems to remove the duplicates from `central-backend` logging when run from `docker-compose`.

I haven't had a chance to test this on a real deployment, but _it works on my machine_ :tm: :grin: 