### PR TITLE
Referrer policy header

### DIFF
--- a/files/nginx/common-headers.nginx.conf
+++ b/files/nginx/common-headers.nginx.conf
@@ -2,6 +2,7 @@
 # which has a call to add_header.
 # See: https://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header
 
+add_header Referrer-Policy same-origin;
 add_header Strict-Transport-Security "max-age=63072000" always;
 add_header X-Frame-Options "SAMEORIGIN";
 add_header X-Content-Type-Options nosniff;


### PR DESCRIPTION
Worth considering while reviewing privacy- & security-related headers.  Ref https://developer.mozilla.org/en-US/docs/Web/Security/Referer_header:_privacy_and_security_concerns

E.g. this will marginally decrease the option of opportunistic credential stealing via basic auth dialog.

> When an external resource(e.g. http://foo.com/image.jpeg) is used as the source of an image tag, if the external resource returns a 401 response code and sets a WWW-Authenticate header then the browsers standard 'Basic authentication' dialogue will pop up.. on the [ODK] page.
> While this is standard (and expected) browser behavior it could confuse users and be used in phishing attacks.
> -- _https://jira.atlassian.com/browse/CONFSERVER-28932_