### PR TITLE
sentry: set environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       - DOMAIN=${DOMAIN}
       - HTTPS_PORT=${HTTPS_PORT:-443}
       - SYSADMIN_EMAIL=${SYSADMIN_EMAIL}
+      - SENTRY_ENVIRONMENT=production
     command: [ "./wait-for-it.sh", "postgres:5432", "--", "./start-odk.sh" ]
     restart: always
     logging:


### PR DESCRIPTION
see: https://docs.sentry.io/platforms/javascript/configuration/environments/

Related to: https://github.com/getodk/central-backend/issues/521, https://github.com/getodk/central-backend/issues/547

This is one axis on which we can filter Sentry issue reports.  Suggested values:

* development: dev.getodk.cloud
* staging: test.getodk.cloud
* production: everything else