### PR TITLE
openssl can fail, leaving an empty file and causing a reboot loop

### DIFF
--- a/files/nginx/odk-setup.sh
+++ b/files/nginx/odk-setup.sh
@@ -1,15 +1,17 @@
+#!/bin/bash
+
 DHPATH=/etc/dh/nginx.pem
-if [ ! -e "$DHPATH" ] && [ "$SSL_TYPE" != "upstream" ]
+if [ ! -s "$DHPATH" ] && [ "$SSL_TYPE" != "upstream" ]
 then
   echo "diffie hellman private key does not exist; creating.."
   openssl dhparam -out "$DHPATH" 2048
 fi
 
 SELFSIGN_BASEPATH=/etc/selfsign/live/$DOMAIN
-if [ "$SSL_TYPE" = "selfsign" ] && [ ! -e "$SELFSIGN_BASEPATH/privkey.pem" ]
+if [ "$SSL_TYPE" = "selfsign" ] && [ ! -s "$SELFSIGN_BASEPATH/privkey.pem" ]
 then
   echo "self-signed cert requested but does not exist; creating.. (this could take a while)"
-  mkdir -p $SELFSIGN_BASEPATH
+  mkdir -p "$SELFSIGN_BASEPATH"
   openssl req -x509 -newkey rsa:4086 \
     -subj "/C=XX/ST=XXXX/L=XXXX/O=XXXX/CN=localhost" \
     -keyout "$SELFSIGN_BASEPATH/privkey.pem" \


### PR DESCRIPTION
openssl can fail, leaving an empty file and causing a reboot loop since `/etc/dh/nginx.pem` cannot be found.

During an upgrade to Central v1.5.3, this is what the user saw when the server did not come up.
![image](https://user-images.githubusercontent.com/32369/192063719-e17129a4-f7d3-415e-97dc-f8960781911d.png)

Logs showed it was an issue with `/etc/dh/nginx.pem`.
![image](https://user-images.githubusercontent.com/32369/192063692-d5526113-ce79-45e0-aee0-18481a902aa5.png)

Not sure what happened, but it seems that for whatever reason, the openssl command failed and resulted in an empty file.

This PR checks for an empty file in all places where openssl is called. I confirmed the syntax is correct with shellcheck. I also wrap the mkdir command in case we ever use a white space in the name.

I confirmed this fix works on the server that had this issue.