### PR TITLE
Add shebangs to all shell scripts

### DIFF
--- a/files/enketo/generate-secrets.sh
+++ b/files/enketo/generate-secrets.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 
 if [ ! -f /etc/secrets/enketo-secret ]; then
   LC_ALL=C tr -dc '[:alnum:]' < /dev/urandom | head -c64 > /etc/secrets/enketo-secret

--- a/files/enketo/start-enketo.sh
+++ b/files/enketo/start-enketo.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 CONFIG_PATH=${ENKETO_SRC_DIR}/config/config.json
 echo "generating enketo configuration.."
 /bin/bash -c "SECRET=$(cat /etc/secrets/enketo-secret) LESS_SECRET=$(cat /etc/secrets/enketo-less-secret) API_KEY=$(cat /etc/secrets/enketo-api-key) envsubst '\$DOMAIN\$HTTPS_PORT:\$SECRET:\$LESS_SECRET:\$API_KEY:\$SUPPORT_EMAIL' < ${CONFIG_PATH}.template > $CONFIG_PATH"

--- a/files/nginx/odk-setup.sh
+++ b/files/nginx/odk-setup.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 DHPATH=/etc/dh/nginx.pem
 if [ ! -e "$DHPATH" ] && [ "$SSL_TYPE" != "upstream" ]
 then

--- a/files/service/scripts/start-odk.sh
+++ b/files/service/scripts/start-odk.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 CONFIG_PATH=/usr/odk/config/local.json
 echo "generating local service configuration.."
 /bin/bash -c "ENKETO_API_KEY=$(cat /etc/secrets/enketo-api-key) envsubst '\$DOMAIN:\$HTTPS_PORT:\$SYSADMIN_EMAIL:\$ENKETO_API_KEY' < /usr/share/odk/config.json.template > $CONFIG_PATH"


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/330

Different shebangs are used because these scripts are currently run in different contexts, specifically:

* `files/enketo/start-enketo.sh`: triggered in `enketo.dockerfile` using [Docker's `CMD`](https://docs.docker.com/engine/reference/builder/#cmd) in _shell_ form; "If you use the shell form of the `CMD`, then the `<command>` will execute in `/bin/sh -c`"
* `files/nginx/odk-setup.sh`: triggered in `nginx.dockerfile`, explicitly using `/bin/bash` there
* `files/service/scripts/start-odk.sh`: triggered via `exec` in `./wait-for-it.sh`, so inherits the shebang from `./wait-for-it.sh`
* `files/enketo/generate-secrets.sh`: triggered by [`docker-compose.yaml`'s `command`](https://docs.docker.com/compose/compose-file/#command), which "overrides...Dockerfile’s `CMD`". so presumably follows the same rules