### PR TITLE
start-enketo: simplify config generation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - checkout
 
       - run: sudo apt install shellcheck
-      - run: cat <(git grep -El '^#!.*sh\b') <(git ls-files | grep -E '.sh$') | sort -u | grep -v '/wait-for-it.sh$' | xargs shellcheck
+      - run: cat <(git grep -El '^#!.*sh\b') <(git ls-files | grep -E '.sh$') | sort -u | grep -v '/wait-for-it.sh$' | xargs shellcheck --exclude=SC2016
 
       - run: git submodule update -i
 

--- a/files/enketo/start-enketo.sh
+++ b/files/enketo/start-enketo.sh
@@ -2,7 +2,13 @@
 
 CONFIG_PATH=${ENKETO_SRC_DIR}/config/config.json
 echo "generating enketo configuration.."
-/bin/bash -c "SECRET=$(cat /etc/secrets/enketo-secret) LESS_SECRET=$(cat /etc/secrets/enketo-less-secret) API_KEY=$(cat /etc/secrets/enketo-api-key) envsubst '\$DOMAIN\$HTTPS_PORT:\$SECRET:\$LESS_SECRET:\$API_KEY:\$SUPPORT_EMAIL' < ${CONFIG_PATH}.template > $CONFIG_PATH"
+
+SECRET=$(cat /etc/secrets/enketo-secret) \
+LESS_SECRET=$(cat /etc/secrets/enketo-less-secret) \
+API_KEY=$(cat /etc/secrets/enketo-api-key) \
+envsubst '$DOMAIN,$HTTPS_PORT,$SECRET,$LESS_SECRET,$API_KEY,$SUPPORT_EMAIL' \
+    < "$CONFIG_PATH.template" \
+    > "$CONFIG_PATH"
 
 echo "starting pm2/enketo.."
 pm2 start --no-daemon app.js -n enketo

--- a/files/nginx/setup-odk.sh
+++ b/files/nginx/setup-odk.sh
@@ -20,7 +20,9 @@ fi
 echo "writing fresh nginx templates..."
 cp /etc/odk/nginx/conf/redirector.conf /etc/nginx/conf.d/redirector.conf
 CNAME=$({ [ "$SSL_TYPE" = "customssl" ] || [ "$SSL_TYPE" = "selfsign" ]; } && echo "local" || echo "$DOMAIN") \
-/bin/bash -c "envsubst '\$CNAME' < /etc/odk/nginx/conf/odk.conf.template > /etc/nginx/conf.d/odk.conf"
+envsubst '$CNAME' \
+    < /etc/odk/nginx/conf/odk.conf.template \
+    > /etc/nginx/conf.d/odk.conf
 
 if [ "$SSL_TYPE" = "letsencrypt" ]; then
   echo "starting nginx with certbot..."

--- a/files/service/scripts/start-odk.sh
+++ b/files/service/scripts/start-odk.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
-CONFIG_PATH=/usr/odk/config/local.json
 echo "generating local service configuration.."
-/bin/bash -c "ENKETO_API_KEY=$(cat /etc/secrets/enketo-api-key) envsubst '\$DOMAIN:\$HTTPS_PORT:\$SYSADMIN_EMAIL:\$ENKETO_API_KEY:\$DB_HOST:\$DB_USER:\$DB_PASSWORD:\$DB_NAME' < /usr/share/odk/config.json.template > $CONFIG_PATH"
+ENKETO_API_KEY=$(cat /etc/secrets/enketo-api-key) \
+envsubst '$DOMAIN:$HTTPS_PORT:$SYSADMIN_EMAIL:$ENKETO_API_KEY:$DB_HOST:$DB_USER:$DB_PASSWORD:$DB_NAME' \
+    < /usr/share/odk/config.json.template \
+    > /usr/odk/config/local.json
 
 SENTRY_RELEASE="$(cat sentry-versions/server)"
 export SENTRY_RELEASE


### PR DESCRIPTION
The original code looks like it's doing something clever (e.g. protecting secrets from leaking into the `pm2` process?), but I can't work out what it is...