### PR TITLE
service: use npm ci

### DIFF
--- a/service.dockerfile
+++ b/service.dockerfile
@@ -20,7 +20,7 @@ RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main" | tee 
 COPY files/service/crontab /etc/cron.d/odk
 
 COPY server/package*.json ./
-RUN npm install --production --legacy-peer-deps
+RUN npm clean-install --production --legacy-peer-deps
 RUN npm install pm2 -g
 
 COPY server/ ./


### PR DESCRIPTION
> This command is similar to npm install, except it's meant to be used
> in automated environments such as test platforms, continuous
> integration, and deployment -- or any situation where you want to
> make sure you're doing a clean install of your dependencies.
>
> - https://docs.npmjs.com/cli/v8/commands/npm-ci/
