### PR TITLE
service: enable legacy-peer-deps for npm install

### DIFF
--- a/service.dockerfile
+++ b/service.dockerfile
@@ -10,7 +10,7 @@ RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main" | tee 
 COPY files/service/crontab /etc/cron.d/odk
 
 COPY server/package*.json ./
-RUN npm install --production
+RUN npm install --production --legacy-peer-deps
 RUN npm install pm2 -g
 
 COPY server/ ./


### PR DESCRIPTION
Required to use @getodk/slonik fork in odk-central-backend.

Accompanies https://github.com/getodk/central-backend/pull/599.