### PR TITLE
Wait for it licence

### DIFF
--- a/files/service/scripts/wait-for-it.sh
+++ b/files/service/scripts/wait-for-it.sh
@@ -1,5 +1,28 @@
 #!/usr/bin/env bash
 #   Use this script to test if a given TCP host/port are available
+#
+# Source: https://github.com/vishnubob/wait-for-it
+#
+# The MIT License (MIT)
+# Copyright (c) 2016 Giles Hall
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 
 cmdname=$(basename $0)
 


### PR DESCRIPTION
The `wait-for-it.sh` script was introduced in fcad46fcd38fb67ecb0cb2631fb66b2904f582ed.

It looks like the version at https://github.com/vishnubob/wait-for-it/blob/8ed92e8cab83cfed76ff012ed4a36cef74b28096/wait-for-it.sh, whose licence is MIT and includes the clause:

> The above copyright notice and this permission notice shall be included in all
> copies or substantial portions of the Software.

See: https://github.com/vishnubob/wait-for-it/blob/8ed92e8cab83cfed76ff012ed4a36cef74b28096/LICENSE.