### PR TITLE
scripts: fail if cd fails

### DIFF
--- a/files/service/scripts/purge-forms.sh
+++ b/files/service/scripts/purge-forms.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -eu
 
 cd /usr/odk
 /usr/local/bin/node lib/bin/purge-forms.js >/proc/1/fd/1 2>/proc/1/fd/2

--- a/files/service/scripts/reap-sessions.sh
+++ b/files/service/scripts/reap-sessions.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -eu
 
 cd /usr/odk
 /usr/local/bin/node lib/bin/reap-sessions.js >/proc/1/fd/1 2>/proc/1/fd/2

--- a/files/service/scripts/run-analytics.sh
+++ b/files/service/scripts/run-analytics.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -eu
 
 cd /usr/odk
 /usr/local/bin/node lib/bin/run-analytics.js >/proc/1/fd/1 2>/proc/1/fd/2

--- a/files/service/scripts/run-backup.sh
+++ b/files/service/scripts/run-backup.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -eu
 
 cd /usr/odk
 /usr/local/bin/node lib/bin/backup.js >/proc/1/fd/1 2>/proc/1/fd/2


### PR DESCRIPTION
These changes resolve the shellcheck violation:

    cd /usr/odk
    ^---------^ SC2164: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.
    
An alternative would be to follow `shellcheck`'s suggestion to add `|| exit` to the `cd` invocations, but adding `-e` will also protect against future changes and seems like a reasonable default for scripts:

```
-e errexit       If not interactive, exit immediately if any untested command fails.  The exit
                 status of a command is considered to be explicitly tested if the command is
                 used to control an if, elif, while, or until; or if the command is the left
                 hand operand of an “&&” or “||” operator.
```

`-u` () is a bonus, which also seems like a sensible default for shell scripts in this repo:

```
-u nounset       Write a message to standard error when attempting to expand a variable that
                 is not set, and if the shell is not interactive, exit immediately.
```