### PR TITLE
Select the PostgreSQL apt repo based on the OS codename

### DIFF
--- a/service.dockerfile
+++ b/service.dockerfile
@@ -2,7 +2,7 @@ FROM node:14.19.3
 
 WORKDIR /usr/odk
 
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list; \
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(grep -oP 'VERSION_CODENAME=\K\w+' /etc/os-release)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list; \
   wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -; \
   apt-get update; \
   apt-get install -y cron gettext postgresql-client-9.6


### PR DESCRIPTION
See https://forum.getodk.org/t/service-image-build-fails-due-to-missing-stretch-pgdg-repository/39528

I don't think the correct approach is to hard-code the repo. We should choose the correct repo based on the OS on image because that OS can change. The alternative is to choose an OS-specific build of node, but that also has problems because we have to know when that OS reaches EOL. 

https://www.postgresql.org/download/linux/debian/ has a similar approach to installing psql. Since we don't have lsb_release (and after installing it in the container I couldn't find the binary), I figured I can grep for the codename instead.

The regex I used was pulled from https://unix.stackexchange.com/questions/13466/can-grep-output-only-specified-groupings-that-match. I tested it both in Debian and Ubuntu to confirm I was pulling the right value.