### PR TITLE
Update news for 1.5.4

### DIFF
--- a/docs/news.html
+++ b/docs/news.html
@@ -8,9 +8,9 @@
   </head>
   <body>
     <div class="news-item">
-      <span class="item-date">2022/09/22</span>
-      <a href="https://forum.getodk.org/t/odk-central-v1-5/37882/4" target="_blank">
-        ODK Central v1.5.3
+      <span class="item-date">2022/11/08</span>
+      <a href="https://forum.getodk.org/t/odk-central-v1-5/37882/5" target="_blank">
+        ODK Central v1.5.4
       </a>
     </div>
     <div class="news-item">


### PR DESCRIPTION
I've linked to the non-existent 5th post in the v1.5.x thread on the forum. Matt will add that post when he releases. Proposed text:

```
ODK Central v1.5.4 is now available. It includes the following change:
* Select the PostgreSQL apt repo based on the OS codename

This change is necessary to build any version of Central. If you need to build an older version of Central, you can manually make the change as described [in this post](https://forum.getodk.org/t/central-service-image-build-fails-due-to-missing-stretch-pgdg-repository/39528/7).

If you are upgrading from a version older than v1.5.3, please read through [the v1.5.3 notes above](https://forum.getodk.org/t/odk-central-v1-5/37882/4).
```

The build fails because of the fix it announces.