### PR TITLE
service.dockerfile: don't use apt-key

### DIFF
--- a/service.dockerfile
+++ b/service.dockerfile
@@ -13,7 +13,7 @@ FROM node:16.17.0
 WORKDIR /usr/odk
 
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(grep -oP 'VERSION_CODENAME=\K\w+' /etc/os-release)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list; \
-  wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -; \
+  curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg; \
   apt-get update; \
   apt-get install -y cron gettext postgresql-client-9.6
 


### PR DESCRIPTION
Closes #352
