### PR TITLE
Run linked commands with &&

### DIFF
--- a/enketo.dockerfile
+++ b/enketo.dockerfile
@@ -14,7 +14,8 @@ COPY files/enketo/config.json.template ${ENKETO_SRC_DIR}/config/config.json.temp
 COPY files/enketo/config.json.template ${ENKETO_SRC_DIR}/config/config.json
 COPY files/enketo/start-enketo.sh ${ENKETO_SRC_DIR}/start-enketo.sh
 
-RUN apt-get update; apt-get install gettext-base
+RUN apt-get update && \
+    apt-get install gettext-base
 
 EXPOSE 8005
 

--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -13,7 +13,8 @@ EXPOSE 443
 VOLUME [ "/etc/dh", "/etc/selfsign", "/etc/nginx/conf.d" ]
 ENTRYPOINT [ "/bin/bash", "/scripts/odk-setup.sh" ]
 
-RUN apt-get update; apt-get install -y openssl netcat nginx-extras lua-zlib
+RUN apt-get update && \
+    apt-get install -y openssl netcat nginx-extras lua-zlib
 
 RUN mkdir -p /etc/selfsign/live/local/
 COPY files/nginx/odk-setup.sh /scripts/

--- a/service.dockerfile
+++ b/service.dockerfile
@@ -12,9 +12,9 @@ FROM node:16.17.0
 
 WORKDIR /usr/odk
 
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(grep -oP 'VERSION_CODENAME=\K\w+' /etc/os-release)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list; \
-  curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg; \
-  apt-get update; \
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(grep -oP 'VERSION_CODENAME=\K\w+' /etc/os-release)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list && \
+  curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg && \
+  apt-get update && \
   apt-get install -y cron gettext postgresql-client-14
 
 COPY files/service/crontab /etc/cron.d/odk


### PR DESCRIPTION
It seems risky to have multiple statements in a single `RUN` instruction.

In this particular example, it's likely that the final step (`apt-get install`) will fail if one or more earlier steps failed.  But replacing `;` with ` && ` means that:

* build will fail faster if an early step fails
* if this pattern is copied elsewhere, we might avoid obscure bugs