### PR TITLE
Upgrade pyxform to v1.11.1 with entity creation support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       options:
         max-file: "30"
   pyxform:
-    image: 'ghcr.io/getodk/pyxform-http:v1.10.1.1'
+    image: 'ghcr.io/getodk/pyxform-http:v1.11.1'
     restart: always
   secrets:
     volumes:


### PR DESCRIPTION
Addresses part of #349

I've upgraded `pyxform` on the staging and dev servers and verified that it works as intended. I believe that without getting this in, it will be reverted on staging if anything else gets merged to `next`.

Given the review and verification we've done, I am fairly confident this is the version we'll release with.