### PR TITLE
frontend: use npm ci

### DIFF
--- a/files/prebuild/build-frontend.sh
+++ b/files/prebuild/build-frontend.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -eu
 cd client
-npm install --no-audit --fund=false --update-notifier=false
+npm clean-install --no-audit --fund=false --update-notifier=false
 npm run build


### PR DESCRIPTION
Depends on #362 - please do not review until that is merged.

> This command is similar to npm install, except it's meant to be used
> in automated environments such as test platforms, continuous
> integration, and deployment -- or any situation where you want to
> make sure you're doing a clean install of your dependencies.
>
> - https://docs.npmjs.com/cli/v8/commands/npm-ci/

