### PR TITLE
Remove Google Drive backups

### DIFF
--- a/files/service/crontab
+++ b/files/service/crontab
@@ -1,4 +1,3 @@
 0 4 * * * root /usr/odk/purge-forms.sh
 0 3 * * * root /usr/odk/run-analytics.sh
-0 2 * * * root /usr/odk/run-backup.sh
 0 1 * * 0 root /usr/odk/reap-sessions.sh

--- a/files/service/scripts/run-backup.sh
+++ b/files/service/scripts/run-backup.sh
@@ -1,5 +1,0 @@
-#!/bin/sh -eu
-
-cd /usr/odk
-/usr/local/bin/node lib/bin/backup.js >/proc/1/fd/1 2>/proc/1/fd/2
-


### PR DESCRIPTION
Progress toward #323.

#### What has been done to verify that this works as intended?

I don't think there's a lot to verify here. With this PR, Central will no longer run the lib/bin/backup.js script in central-backend. We will remove that script in a separate Backend PR.

#### Why is this the best possible solution? Were any other approaches considered?

We have to remove run-backup.sh from the crontab. That's the only place that run-backup.sh is used, so we can also remove run-backup.sh.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This change should be low-risk. The main regression risks will come with the changes to central-backend, which will happen in a separate PR.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

getodk/docs#1535

#### Before submitting this PR, please make sure you have:

- [x] verified that any code or assets from external sources are properly credited in comments.