### PR TITLE
Update pyxform to v1.12.0 to support big-image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       options:
         max-file: "30"
   pyxform:
-    image: 'ghcr.io/getodk/pyxform-http:v1.11.1'
+    image: 'ghcr.io/getodk/pyxform-http:v1.12.0'
     restart: always
   secrets:
     volumes:


### PR DESCRIPTION
Closes #349

#### What has been done to verify that this works as intended?
Put on dev server, converted a form with `big-image`, verified it works as expected.

#### Why is this the best possible solution? Were any other approaches considered?
This updates to the latest version of https://github.com/getodk/pyxform-http which was updated to the latest version of https://github.com/xlsform/pyxform

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Risk of regression is isolated to pyxform entities and media functionality. Both were reviewed and were fairly simple changes so are low-risk.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.
https://github.com/getodk/docs/issues/1549

#### Before submitting this PR, please make sure you have:

- [x] verified that any code or assets from external sources are properly credited in comments.