### PR TITLE
Upgrade from node 16.17.0 to 16.19.1

### DIFF
--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.17.0 as intermediate
+FROM node:16.19.1 as intermediate
 
 COPY ./ ./
 RUN files/prebuild/write-version.sh

--- a/secrets.dockerfile
+++ b/secrets.dockerfile
@@ -1,2 +1,2 @@
-FROM node:16.17.0
+FROM node:16.19.1
 COPY files/enketo/generate-secrets.sh ./

--- a/service.dockerfile
+++ b/service.dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.17.0 as intermediate
+FROM node:16.19.1 as intermediate
 
 COPY . .
 RUN mkdir /tmp/sentry-versions


### PR DESCRIPTION
This should be a safe upgrade. I've looked through the [v16](https://raw.githubusercontent.com/nodejs/node/main/doc/changelogs/CHANGELOG_V16.md) and I didn't see anything concerning. 