### PR TITLE
Change from nashmi/smtp to the more maintained ixdotai/smtp

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       POSTGRES_DATABASE: odk
     restart: always
   mail:
-    image: "itsissa/namshi-smtp:4.92-8.deb10u6"
+    image: "ixdotai/smtp:v0.2.0"
     volumes:
       - ./files/dkim/config:/etc/exim4/_docker_additional_macros:ro
       - ./files/dkim/rsa.private:/etc/exim4/domain.key:ro

--- a/files/service/config.json.template
+++ b/files/service/config.json.template
@@ -11,7 +11,8 @@
       "transport": "smtp",
       "transportOpts": {
         "host": "mail",
-        "port": 25
+        "port": 25,
+        "ignoreTLS": true
       }
     },
     "xlsform": {


### PR DESCRIPTION
This PR introduces the maintained, drop-in replacement for namshi/smtp. https://github.com/namshi/docker-smtp/issues/81#issuecomment-916291013

I tested this by starting with a v2023.1.0 install, changing to this container, rebuilding, and sending a password reset email through an AWS SMTP server. I've also tested sending a password reset email through the server itself. 

The reason for `ignoreTLS` is that exim now generates a self-signed cert and advertises itself as a TLS-enabled server. nodemailer, the Central library that sends the emails, doesn't like self-signed certs, so that's why there is a few flag.

Alternatives I rejected:
* add `MAIN_TLS_ENABLE = false` to _docker_additional_macros fails because TLS support is compiled in. https://www.exim.org/exim-html-current/doc/html/spec_html/ch-main_configuration.html suggests there is no way to turn it off.
* use [rejectUnauthorized](https://nodemailer.com/smtp/#3-allow-self-signed-certificates) in docker-compose. It's harder to add/remove and resolve conflicts. It feels clearer to ignore all of TLS and tell people to remove that line when using a custom mail client.
* build my own SMTP image. Seemed unwise to add to our maintenance burden. 

I did not test a DKIM setup, but we were on exim 4.92 and we are now on exim 4.97. I don't expect any breaking changes and https://github.com/Exim/exim/blob/master/doc/doc-txt/ChangeLog doesn't suggest that there are. Also, I doubt a lot of people use the DKIM option.