### PR TITLE
Upgrade to redis 7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,7 @@ services:
       - SUPPORT_EMAIL=${SYSADMIN_EMAIL}
       - HTTPS_PORT=${HTTPS_PORT:-443}
   enketo_redis_main:
-    image: redis:5
+    image: redis:7.0.8
     volumes:
       - ./files/enketo/redis-enketo-main.conf:/usr/local/etc/redis/redis.conf:ro
       - enketo_redis_main:/data
@@ -94,7 +94,7 @@ services:
       - /usr/local/etc/redis/redis.conf
     restart: always
   enketo_redis_cache:
-    image: redis:5
+    image: redis:7.0.8
     volumes:
       - ./files/enketo/redis-enketo-cache.conf:/usr/local/etc/redis/redis.conf:ro
       - enketo_redis_cache:/data


### PR DESCRIPTION
https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/VersionManagementConsiderations.html suggest upgrades to 6.0 are very safe. Kobo runs [6.2](https://github.com/kobotoolbox/kobo-docker/blob/HEAD/docker-compose.backend.template.yml#L42) so that’s also likely safe. I wanted to push the boundaries and try the latest.

I tested this works by starting with a v2023.1.0 install...
* Confirm form preview, form submission, and form edit work before upgrade.
* Confirm form preview, form submission, form edit, and web link submission, work on same form after upgrade.
* Confirm form preview, form submission, and form edit work a new form after upgrade.

