### PR TITLE
Remove resolved TODO

### DIFF
--- a/postgres_upgrade.dockerfile
+++ b/postgres_upgrade.dockerfile
@@ -4,7 +4,6 @@ FROM tianon/postgres-upgrade:9.6-to-14
 # This file is required to encourage human validation of the process.
 # It's expected it will be provided by the sysadmin performing the upgrade.
 # Docker build will fail if this file is missing.
-# TODO this file may stick around for a while; maybe we should call this simply `use-postgres14`?
 COPY ./files/allow-postgres14-upgrade .
 
 COPY files/postgres/upgrade-postgres.sh /usr/local/bin/


### PR DESCRIPTION
Users are generally going to copy these instructions so the path doesn't really matter. We want to keep it out of the root.