### PR TITLE
Only use named volumes for generated files to prevent compose copy fa…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,8 +61,8 @@ services:
       driver: local
   nginx:
     volumes:
-      - letsencrypt:/etc/letsencrypt
       - nginx:/etc/odk/nginx
+      - nginx_letsencrypt:/etc/letsencrypt
     build:
       context: .
       dockerfile: nginx.dockerfile
@@ -133,4 +133,4 @@ volumes:
   enketo_redis_main:
   enketo_redis_cache:
   nginx:
-  letsencrypt:
+  nginx_letsencrypt:

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -14,7 +14,7 @@ server {
 
   server_tokens off;
 
-  include /etc/odk/nginx/conf/common-headers.conf;
+  include /usr/share/odk/nginx/conf/common-headers.conf;
 
   client_max_body_size 100m;
 
@@ -59,11 +59,11 @@ server {
     root /usr/share/nginx/html;
 
     location /version.txt {
-      include /etc/odk/nginx/conf/common-headers.conf;
+      include /usr/share/odk/nginx/conf/common-headers.conf;
       add_header Cache-Control no-cache;
     }
     location /index.html {
-      include /etc/odk/nginx/conf/common-headers.conf;
+      include /usr/share/odk/nginx/conf/common-headers.conf;
       add_header Cache-Control no-cache;
     }
   }

--- a/files/nginx/setup-odk.sh
+++ b/files/nginx/setup-odk.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 
-DH_PATH=/etc/odk/nginx/ssl_dhparam.pem
+NGINX_PATH=/etc/odk/nginx
+
+DH_PATH="$NGINX_PATH/ssl_dhparam.pem"
 if [ "$SSL_TYPE" != "upstream" ] && [ ! -s "$DH_PATH" ]; then
-  echo "diffie hellman key does not exist; creating (this could take a while)..."
   openssl dhparam -out "$DH_PATH" 2048
 fi
 
-SELFSIGN_PATH=/etc/odk/nginx/selfsign
+SELFSIGN_PATH="$NGINX_PATH/selfsign"
 if [ "$SSL_TYPE" = "selfsign" ] && [ ! -s "$SELFSIGN_PATH/privkey.pem" ]; then
-  echo "self-signed cert does not exist; creating (this could take a while)..."
+  mkdir -p "$SELFSIGN_PATH"
   openssl req -x509 -newkey rsa:4086 \
     -subj "/C=XX/ST=XXXX/L=XXXX/O=XXXX/CN=localhost" \
     -keyout "$SELFSIGN_PATH/privkey.pem" \
@@ -18,27 +19,28 @@ fi
 
 # start from fresh templates in case ssl type has changed
 echo "writing fresh nginx templates..."
-cp /etc/odk/nginx/conf/redirector.conf /etc/nginx/conf.d/redirector.conf
+cp /usr/share/odk/nginx/conf/redirector.conf /etc/nginx/conf.d/redirector.conf
 CNAME=$({ [ "$SSL_TYPE" = "customssl" ] || [ "$SSL_TYPE" = "selfsign" ]; } && echo "local" || echo "$DOMAIN") \
 envsubst '$CNAME' \
-    < /etc/odk/nginx/conf/odk.conf.template \
-    > /etc/nginx/conf.d/odk.conf
+  < /usr/share/odk/nginx/conf/odk.conf.template \
+  > /etc/nginx/conf.d/odk.conf
 
 if [ "$SSL_TYPE" = "letsencrypt" ]; then
   echo "starting nginx with certbot..."
   /bin/bash /scripts/start_nginx_certbot.sh
 elif [ "$SSL_TYPE" = "customssl" ] || [ "$SSL_TYPE" = "selfsign" ]; then
-  echo "starting nginx without certbot..."
+  CERT_PATH=$( [ "$SSL_TYPE" = "customssl" ] && echo "/usr/share/odk/nginx/customssl" || echo "$SELFSIGN_PATH") 
+  # replace letsencrypt cert locations with customssl/selfsign location
+  perl -i -pe "s|/etc/letsencrypt/live/local|$CERT_PATH|;" /etc/nginx/conf.d/odk.conf
   # strip out HTTP-01 ACME challenge location
   perl -i -ne 'print if $. < 7 || $. > 14' /etc/nginx/conf.d/redirector.conf
-  # replace letsencrypt cert locations with customssl or selfsign locations
-  perl -i -pe "s|/etc/letsencrypt/live/local|/etc/odk/nginx/$SSL_TYPE|;" /etc/nginx/conf.d/odk.conf
+  echo "starting nginx without certbot..."
   nginx -g "daemon off;"
 elif [ "$SSL_TYPE" = "upstream" ]; then
-  echo "starting nginx without local SSL to allow for upstream SSL..."
   # strip out all ssl_* directives
   perl -i -ne 's/listen 443.*/listen 80;/; print if ! /ssl_/' /etc/nginx/conf.d/odk.conf
   # force https because we expect SSL upstream
   perl -i -pe 's/X-Forwarded-Proto \$scheme/X-Forwarded-Proto https/;' /etc/nginx/conf.d/odk.conf
+  echo "starting nginx without local SSL to allow for upstream SSL..."
   nginx -g "daemon off;"
 fi

--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -15,18 +15,13 @@ ENTRYPOINT [ "/bin/bash", "/scripts/setup-odk.sh" ]
 
 RUN apt-get update && apt-get install -y netcat-openbsd
 
-# letsencrypt certs are managed by nginx-certbot in /etc/letsencrypt
-RUN mkdir -p /etc/odk/nginx/selfsign
-RUN mkdir -p /etc/odk/nginx/customssl
-RUN mkdir -p /etc/odk/nginx/conf
-
-# remove old configs to prevent upgrade conflicts
-RUN rm -rf /etc/odk/nginx/conf/*
-RUN rm -rf /etc/nginx/conf.d/*
+# letsencrypt and selfsigned certs are managed in setup-odk.sh
+RUN mkdir -p /usr/share/odk/nginx/customssl
+RUN mkdir -p /usr/share/odk/nginx/conf
 
 COPY files/nginx/setup-odk.sh /scripts/
-COPY files/local/customssl/*.pem /etc/odk/nginx/customssl/
-COPY files/nginx/*.conf* /etc/odk/nginx/conf/
+COPY files/local/customssl/*.pem /usr/share/odk/nginx/customssl/
+COPY files/nginx/*.conf* /usr/share/odk/nginx/conf/
 
 COPY --from=intermediate client/dist/ /usr/share/nginx/html
 COPY --from=intermediate /tmp/version.txt /usr/share/nginx/html


### PR DESCRIPTION
Move static files from `/etc/odk` to `/usr/share/odk`. This move is necessary because dockerfile copy commands don't seem to copy files to mounted volumes.

Other changes
* Remove unnecessary rm's to clean up directories. We copy just what we need, so upgrades should be fine.
* Rename letsencrypt volume to associate it with the container.
* Remove unnecessary echos since openssl writes its own helpful output

What I tested
* Fresh install: confirmed with `docker volume ls` that nothing exists. 
* Fresh install with letsecnrupt gets new certs. Also remove nginx, rebuild and confirmed certs are still used.
* Fresh install with selfsignSSL gets correct certs.
* Can toggle between letsencrypt and selfsign with a build and an up.
* Changing odk.conf.template gets the correct file to show up in the container after a build

I did not test
* customssl
