### PR TITLE
Don't use named volumes for nginx

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,9 +60,6 @@ services:
     logging:
       driver: local
   nginx:
-    volumes:
-      - nginx:/etc/odk/nginx
-      - nginx_letsencrypt:/etc/letsencrypt
     build:
       context: .
       dockerfile: nginx.dockerfile
@@ -132,5 +129,3 @@ volumes:
   postgres14:
   enketo_redis_main:
   enketo_redis_cache:
-  nginx:
-  nginx_letsencrypt:

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -2,19 +2,19 @@ server {
   listen 443 ssl;
   server_name ${CNAME};
 
-  ssl_certificate /etc/letsencrypt/live/${CNAME}/fullchain.pem;
-  ssl_certificate_key /etc/letsencrypt/live/${CNAME}/privkey.pem;
-  ssl_trusted_certificate /etc/letsencrypt/live/${CNAME}/fullchain.pem;
+  ssl_certificate /etc/${SSL_TYPE}/live/${CNAME}/fullchain.pem;
+  ssl_certificate_key /etc/${SSL_TYPE}/live/${CNAME}/privkey.pem;
+  ssl_trusted_certificate /etc/${SSL_TYPE}/live/${CNAME}/fullchain.pem;
 
   ssl_protocols TLSv1.2 TLSv1.3;
   ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
   ssl_prefer_server_ciphers off;
 
-  ssl_dhparam /etc/odk/nginx/ssl_dhparam.pem;
+  ssl_dhparam /etc/dh/nginx.pem;
 
   server_tokens off;
 
-  include /usr/share/odk/nginx/conf/common-headers.conf;
+  include /usr/share/odk/nginx/common-headers.conf;
 
   client_max_body_size 100m;
 
@@ -59,11 +59,11 @@ server {
     root /usr/share/nginx/html;
 
     location /version.txt {
-      include /usr/share/odk/nginx/conf/common-headers.conf;
+      include /usr/share/odk/nginx/common-headers.conf;
       add_header Cache-Control no-cache;
     }
     location /index.html {
-      include /usr/share/odk/nginx/conf/common-headers.conf;
+      include /usr/share/odk/nginx/common-headers.conf;
       add_header Cache-Control no-cache;
     }
   }

--- a/files/nginx/setup-odk.sh
+++ b/files/nginx/setup-odk.sh
@@ -1,13 +1,11 @@
 #!/bin/bash
 
-NGINX_PATH=/etc/odk/nginx
-
-DH_PATH="$NGINX_PATH/ssl_dhparam.pem"
+DH_PATH=/etc/dh/nginx.pem
 if [ "$SSL_TYPE" != "upstream" ] && [ ! -s "$DH_PATH" ]; then
   openssl dhparam -out "$DH_PATH" 2048
 fi
 
-SELFSIGN_PATH="$NGINX_PATH/selfsign"
+SELFSIGN_PATH="/etc/selfsign/live/$DOMAIN"
 if [ "$SSL_TYPE" = "selfsign" ] && [ ! -s "$SELFSIGN_PATH/privkey.pem" ]; then
   mkdir -p "$SELFSIGN_PATH"
   openssl req -x509 -newkey rsa:4086 \
@@ -19,28 +17,28 @@ fi
 
 # start from fresh templates in case ssl type has changed
 echo "writing fresh nginx templates..."
-cp /usr/share/odk/nginx/conf/redirector.conf /etc/nginx/conf.d/redirector.conf
-CNAME=$({ [ "$SSL_TYPE" = "customssl" ] || [ "$SSL_TYPE" = "selfsign" ]; } && echo "local" || echo "$DOMAIN") \
-envsubst '$CNAME' \
-  < /usr/share/odk/nginx/conf/odk.conf.template \
+cp /usr/share/odk/nginx/redirector.conf /etc/nginx/conf.d/redirector.conf
+CNAME=$( [ "$SSL_TYPE" = "customssl" ] && echo "local" || echo "$DOMAIN") \
+envsubst '$SSL_TYPE $CNAME' \
+  < /usr/share/odk/nginx/odk.conf.template \
   > /etc/nginx/conf.d/odk.conf
 
 if [ "$SSL_TYPE" = "letsencrypt" ]; then
-  echo "starting nginx with certbot..."
+  echo "starting nginx for letsencrypt..."
   /bin/bash /scripts/start_nginx_certbot.sh
-elif [ "$SSL_TYPE" = "customssl" ] || [ "$SSL_TYPE" = "selfsign" ]; then
-  CERT_PATH=$( [ "$SSL_TYPE" = "customssl" ] && echo "/usr/share/odk/nginx/customssl" || echo "$SELFSIGN_PATH") 
-  # replace letsencrypt cert locations with customssl/selfsign location
-  perl -i -pe "s|/etc/letsencrypt/live/local|$CERT_PATH|;" /etc/nginx/conf.d/odk.conf
-  # strip out HTTP-01 ACME challenge location
-  perl -i -ne 'print if $. < 7 || $. > 14' /etc/nginx/conf.d/redirector.conf
-  echo "starting nginx without certbot..."
-  nginx -g "daemon off;"
-elif [ "$SSL_TYPE" = "upstream" ]; then
-  # strip out all ssl_* directives
-  perl -i -ne 's/listen 443.*/listen 80;/; print if ! /ssl_/' /etc/nginx/conf.d/odk.conf
-  # force https because we expect SSL upstream
-  perl -i -pe 's/X-Forwarded-Proto \$scheme/X-Forwarded-Proto https/;' /etc/nginx/conf.d/odk.conf
-  echo "starting nginx without local SSL to allow for upstream SSL..."
+else
+  if [ "$SSL_TYPE" = "upstream" ]; then
+    # no need for letsencrypt challenge reply or 80 to 443 redirection
+    rm -f /etc/nginx/conf.d/redirector.conf
+    # strip out all ssl_* directives
+    perl -i -ne 's/listen 443.*/listen 80;/; print if ! /ssl_/' /etc/nginx/conf.d/odk.conf
+    # force https because we expect SSL upstream
+    perl -i -pe 's/X-Forwarded-Proto \$scheme/X-Forwarded-Proto https/;' /etc/nginx/conf.d/odk.conf
+    echo "starting nginx for upstream ssl..."
+  else
+    # remove letsencrypt challenge reply, but keep 80 to 443 redirection
+    perl -i -ne 'print if $. < 7 || $. > 14' /etc/nginx/conf.d/redirector.conf
+    echo "starting nginx for custom ssl and self-signed certs..."
+  fi
   nginx -g "daemon off;"
 fi

--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -11,17 +11,16 @@ FROM jonasal/nginx-certbot:4.2.0
 EXPOSE 80
 EXPOSE 443
 
+VOLUME [ "/etc/dh", "/etc/selfsign", "/etc/nginx/conf.d" ]
 ENTRYPOINT [ "/bin/bash", "/scripts/setup-odk.sh" ]
 
 RUN apt-get update && apt-get install -y netcat-openbsd
 
-# letsencrypt and selfsigned certs are managed in setup-odk.sh
-RUN mkdir -p /usr/share/odk/nginx/customssl
-RUN mkdir -p /usr/share/odk/nginx/conf
+RUN mkdir -p /usr/share/odk/nginx/
 
 COPY files/nginx/setup-odk.sh /scripts/
-COPY files/local/customssl/*.pem /usr/share/odk/nginx/customssl/
-COPY files/nginx/*.conf* /usr/share/odk/nginx/conf/
+COPY files/local/customssl/*.pem /etc/customssl/live/local/
+COPY files/nginx/*.conf* /usr/share/odk/nginx/
 
 COPY --from=intermediate client/dist/ /usr/share/nginx/html
 COPY --from=intermediate /tmp/version.txt /usr/share/nginx/html


### PR DESCRIPTION
After some discussion with @lognaturel, we've decided that transient volumes are OK for letsencrypt certs. 

Our previous changes didn't address the issue of accidentally requesting multiple certs when rebuilding, and we've confirmed that multiple builds don't actually request more certs. It's only when you do a docker-compose down or build a totally new machine that this is problem. That is to say, it's a problem for ODK Cloud but not for most people.

We've decided to use `/usr/share/odk/nginx/` as the directory we use so we don't accidentally clobber something in `/usr/share/nginx`/.

This PR was confirmed working by testing current version of Central with LetsEncrypt, then applying this PR, and running ` docker compose build && docker compose up -d`. A new cert was requested, but everything worked. Another rebuild worked with no cert requested. Then switched to self-sign, rebuilt, and that worked as well.
