### PR TITLE
Remove instructions.md

### DIFF
--- a/instructions.md
+++ b/instructions.md
@@ -1,3 +1,0 @@
-1. back up your data!
-2. `./upgrade.sh`
-+ something about pruning


### PR DESCRIPTION
Targeting the `master` branch rather than `next` because this is a no-op change to docs.