### PR TITLE
Use pm2-runtime with Enketo to ensure quick stop

### DIFF
--- a/files/enketo/start-enketo.sh
+++ b/files/enketo/start-enketo.sh
@@ -12,4 +12,4 @@ envsubst '$DOMAIN $BASE_URL $SECRET $LESS_SECRET $API_KEY $SUPPORT_EMAIL' \
     > "$CONFIG_PATH"
 
 echo "starting pm2/enketo.."
-pm2 start --no-daemon app.js -n enketo
+pm2-runtime app.js -n enketo


### PR DESCRIPTION
Mirror the change in https://github.com/enketo/enketo-express/pull/533 and the `pm2-runtime` usage in https://github.com/getodk/central/blob/0502d5397faf42b641a16487dbcdea10de418dea/files/service/scripts/start-odk.sh#L43