### PR TITLE
Speed up stopping containers

### DIFF
--- a/enketo.dockerfile
+++ b/enketo.dockerfile
@@ -19,4 +19,4 @@ RUN apt-get update && \
 
 EXPOSE 8005
 
-CMD ./start-enketo.sh
+CMD ["./start-enketo.sh"]

--- a/files/enketo/start-enketo.sh
+++ b/files/enketo/start-enketo.sh
@@ -12,4 +12,4 @@ envsubst '$DOMAIN $BASE_URL $SECRET $LESS_SECRET $API_KEY $SUPPORT_EMAIL' \
     > "$CONFIG_PATH"
 
 echo "starting pm2/enketo.."
-pm2-runtime app.js -n enketo
+exec pm2-runtime app.js -n enketo

--- a/files/nginx/setup-odk.sh
+++ b/files/nginx/setup-odk.sh
@@ -40,5 +40,5 @@ else
     perl -i -ne 'print if $. < 7 || $. > 14' /etc/nginx/conf.d/redirector.conf
     echo "starting nginx for custom ssl and self-signed certs..."
   fi
-  nginx -g "daemon off;"
+  exec nginx -g "daemon off;"
 fi

--- a/files/service/scripts/start-odk.sh
+++ b/files/service/scripts/start-odk.sh
@@ -40,5 +40,4 @@ fi
 echo "using $WORKER_COUNT worker(s) based on available memory ($MEMTOT).."
 
 echo "starting server."
-pm2-runtime ./pm2.config.js
-
+exec pm2-runtime ./pm2.config.js


### PR DESCRIPTION
Closes #416

#### What has been done to verify that this works as intended?
Did a `docker compose build` `docker compose up -d` `docker compose stop` after each commit to make sure each was minimal and effective. It's still on there if someone wants to do a sanity check.

#### Why is this the best possible solution? Were any other approaches considered?
The underlying issue is that signals weren't being proxied to the intended processes. More at https://stackoverflow.com/a/32261019/137744. This was addressed by running all the various processes with `exec`.

Additionally, the Enketo dockerfile needed to be updated to use the JSON-array syntax so it wouldn't be called with `/bin/sh -c` which is immune to SIGTERM

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This is an ops change. Worst case would be things don't stop or come up. I think if it works on dev it's likely to work anywhere.

I'm not entirely sure about risk beyond things not stopping or coming up. ~I keep seeing things about the [PID 1 zombie reaping problem](https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem/) but I can't tell if this changes anything with respect to that. [This post](https://petermalmgren.com/signal-handling-docker/) suggests that it doesn't change anything.~ [This `tini` post has more about zombie processes](https://github.com/krallin/tini/issues/8#issuecomment-146135930). Given my understanding of the processes we launch, I believe it's unlikely that any secondary processes likely to become zombies are being launched.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced