### PR TITLE
Replace Fathom with Cloudflare

### DIFF
--- a/docs/news.html
+++ b/docs/news.html
@@ -4,7 +4,6 @@
     <meta charset="utf-8">
     <title>ODK Central</title>
     <link rel="stylesheet" href="style.css">
-    <script src="https://helper.getodk.org/script.js" data-site="PBSTMJFG" defer></script>
   </head>
   <body>
     <div class="news-item">
@@ -19,5 +18,6 @@
         ODK Central v2023.1
       </a>
     </div>
+    <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "81f288331d6e4638be205e0e63388165"}'></script>
   </body>
 </html>


### PR DESCRIPTION
Fathom's custom domains are the reason I picked them but that feature doesn't work anymore. Also, it's gotten very expensive for what we use it for.