### PR TITLE
Update pyxform and Enketo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,7 +96,7 @@ services:
       options:
         max-file: "30"
   pyxform:
-    image: 'ghcr.io/getodk/pyxform-http:v1.12.0'
+    image: 'ghcr.io/getodk/pyxform-http:v1.12.1'
     restart: always
   secrets:
     volumes:

--- a/enketo.dockerfile
+++ b/enketo.dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/enketo/enketo-express:6.0.0
+FROM ghcr.io/enketo/enketo-express:6.1.0
 
 ENV ENKETO_SRC_DIR=/srv/src/enketo_express
 WORKDIR ${ENKETO_SRC_DIR}


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/409

pyxform has a small bug fix.

Enketo has some risk but has been running on https://getodk.org/xlsform and on the QA server for some days.