### PR TITLE
Add 5G buffer to space required for postgres upgrade

### DIFF
--- a/files/postgres14/upgrade/check-available-space
+++ b/files/postgres14/upgrade/check-available-space
@@ -31,7 +31,7 @@ if [[ "$volume" = "" ]]; then
   exit 1
 fi
 mountpoint="$(docker volume inspect --format='{{.Mountpoint}}' "$volume")"
-used="$(du -s "$mountpoint" | cut -f1)"
+used="$(( $(du -s "$mountpoint" | cut -f1) + 5000000 ))" # add 5G of buffer
 
 log
 log "    Free space: $(numfmt --to=si "$((free*1000))")B"


### PR DESCRIPTION
Closes #424

<!-- Please branch off and target the next branch unless you are only changing documentation like the readme. The master branch is a stable branch deployed in production. -->

#### What has been done to verify that this works as intended?
On the dev server, I changed the line changed by this PR to 

```bash
used="$(( $(du -s /var/lib/docker | cut -f1) + 5000000" )) # add 5G of buffer
```

There's about 11G of stuff in that folder and I confirmed that the script said I needed 17G for the update.

I don't have a good strategy for requesting the space check when the migration has already been done (and there's no `postgres` container). I think this is good enough but the reviewer should see whether they agree!

#### Why is this the best possible solution? Were any other approaches considered?

I considered telling the user we were adding a buffer or only adding it in the error message. But this is simple and feels like the most fool-proof.

The issue mentioned the possibility of 10Gb of buffer. That seemed extreme to me.

I'm not totally sure whether the [arithmetic expansion](https://tldp.org/LDP/abs/html/arithexp.html) is necessary (it worked for me without) but I figure it can't hurt.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Risk is isolated to space determination. It might be broken.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced