### PR TITLE
Rename POSTGRES_DB env var

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     environment:
       POSTGRES_USER: odk
       POSTGRES_PASSWORD: odk
-      POSTGRES_DATABASE: odk
+      POSTGRES_DB: odk
     restart: always
   postgres:
     # This service upgrades from postgres 9.6 to 14.
@@ -25,7 +25,7 @@ services:
       PGUSER: odk
       POSTGRES_INITDB_ARGS: -U odk
       POSTGRES_PASSWORD: odk
-      POSTGRES_DATABASE: odk
+      POSTGRES_DB: odk
   mail:
     image: "ixdotai/smtp:v0.2.0"
     volumes:


### PR DESCRIPTION
Both of our base images ultimately inherit from the official docker-postgres image.  This has an env var POSTGRES_DB, and has never referenced POSTGRES_DATABASE.

See: https://hub.docker.com/_/postgres/
See: https://github.com/docker-library/postgres
