### PR TITLE
fixes #438

### DIFF
--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -25,7 +25,7 @@ server {
   gzip_types text/plain text/css application/json application/x-javascript text/xml text/csv;
 
   location /- {
-    proxy_pass http://enketo:8005/-;
+    proxy_pass http://enketo:8005;
     proxy_redirect off;
     proxy_set_header Host $host;
 


### PR DESCRIPTION
fixes #438: if URI is given in proxy_pass then nginx decodes and re-encodes path
which breaks submission attachment with special characters in webform more details: https://trac.nginx.org/nginx/ticket/2506

#### What has been done to verify that this works as intended?

Manually verified it locally and on Dev server

#### Why is this the best possible solution? Were any other approaches considered?

This is simplest and safest fix. I am going to create separate issue to investigate encoding protocol between Central and Enketo.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

None

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

None

#### Before submitting this PR, please make sure you have:

- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced