### PR TITLE
Add template for bug reports by QA team

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,25 @@
+<!--
+The Central team uses GitHub issues for project management. Most bug reports and feature requests should start in the ODK forum: https://forum.getodk.org
+
+The QA team uses the template below to file bug reports. If you are not filing a bug report, feel free to clear the template.
+-->
+
+#### Problem description
+
+#### URL of the page
+
+#### Steps to reproduce the problem
+
+#### Screenshot
+
+Please don't attach images of QR codes, as those provide access to the server.
+
+#### Expected behavior
+
+#### Central version shown in version.txt
+
+#### Browser version
+
+#### Around when did you see the problem (in UTC)?
+
+#### Other notes (if any)


### PR DESCRIPTION
This PR adds an issue template that @srujner and @dbemke can use when filing issues. I modified the [Collect issue template](https://github.com/getodk/collect/blob/2d544e1a78174f0427b6f81bc35b6c7baac2c99d/.github/ISSUE_TEMPLATE.md). Suggestions welcome!