### PR TITLE
Fix email sending templating bug

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       - DB_PASSWORD=${DB_PASSWORD:-odk}
       - DB_NAME=${DB_NAME:-odk}
       - DB_SSL=${DB_SSL:-null}
-      - EMAIL_FROM=${EMAIL_FROM:-no-reply@${DOMAIN}}
+      - EMAIL_FROM=${EMAIL_FROM:-no-reply@$DOMAIN}
       - EMAIL_HOST=${EMAIL_HOST:-mail}
       - EMAIL_PORT=${EMAIL_PORT:-25}
       - EMAIL_SECURE=${EMAIL_SECURE:-false}


### PR DESCRIPTION
Closes #454 

#### What has been done to verify that this works as intended?

I ran `docker compose config | grep EMAIL_FROM` to see what the config was. 

* with EMAIL_FROM in .env set to odk@foo.org, I get odk@foo.org in the output. 
* with EMAIL_FROM in .env commented out, I get no-reply@odk-central.foo.org in the output.

I also confirmed that emails are delivered with this change.

#### Why is this the best possible solution? Were any other approaches considered?

There might be a bug in docker/compose v2.20.2/24.0.5, but thankfully https://docs.docker.com/compose/environment-variables/env-file/#parameter-expansion says unbraced vars are supported, so that's why this change works.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

It should only affect people who might have changed docker-compose.yml. If something's broken when they upgrade, it will be pretty easy to see because they can't create or reset web users. Hopefully that will lead to a forum post or this issuel.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [X] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced