### PR TITLE
Adjust container name if you have compose v2

### DIFF
--- a/files/postgres14/upgrade/check-available-space
+++ b/files/postgres14/upgrade/check-available-space
@@ -15,7 +15,14 @@ fi
 dockerRootDir="$(docker info --format '{{print .DockerRootDir}}')"
 free="$(df --output=avail "$dockerRootDir/volumes" | tail -n+2)"
 
-containerName="central_postgres_1"
+# Support both Docker Compose v1 & v2 container names.
+# See: https://docs.docker.com/compose/migrate/#service-container-names
+if ! docker compose version >/dev/null 2>/dev/null; then
+  containerName="central_postgres_1"
+else
+  containerName="central-postgres-1"
+fi
+
 # The --format argument is a Go template.  Adding spaces between the
 # curlies seems to affect the output.  For more info on this
 # wonderful language, see:


### PR DESCRIPTION
Closes #439

Sometimes people run the disk space checker after a failed upgrade or maybe they are using compose v2 with an pre-migration install. See https://forum.getodk.org/t/stuck-on-central-upgrade/41421/3

This is an issue because v1 used `_` in names and v2 uses `-`.

#### What has been done to verify that this works as intended?
Ran the script on a machine with compose v2. I did NOT run it on a machine with v1.

#### Why is this the best possible solution? Were any other approaches considered?
The change isn't very robust because you could have used compose v1 to setup Central and still have v2 in your path, but I can't think of a way to check what version of compose was used to setup the current install.

You can force docker to [use the v1 scheme](https://stackoverflow.com/questions/69464001/docker-compose-container-name-use-dash-instead-of-underscore), but that doesn't really help with this script.

Anyway, seems like this change is not perfect, but it helps.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Slight improvement to running migration.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:

- [X] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced