### PR TITLE
Update Enketo version to 6.2.2

### DIFF
--- a/enketo.dockerfile
+++ b/enketo.dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/enketo/enketo-express:6.2.0
+FROM ghcr.io/enketo/enketo-express:6.2.2
 
 ENV ENKETO_SRC_DIR=/srv/src/enketo_express
 WORKDIR ${ENKETO_SRC_DIR}


### PR DESCRIPTION
Closes #441 

We merged a couple of risky prs to pyxform so I think we should hold off a little longer on releasing and upgrading as we catch things from https://getodk.org/xlsform/

We don't have another Enketo release planned. 6.2.2 has been on the dev server and https://getodk.org/xlsform/ for about a week now.