### PR TITLE
Improve DKIM support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@
 !/files/postgres14/upgrade/check-available-space
 
 /files/local/customssl/*.pem
+
+/files/mail/rsa.private
+/files/mail/rsa.public
+
+/files/dkim/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,12 +27,12 @@ services:
       POSTGRES_PASSWORD: odk
       POSTGRES_DATABASE: odk
   mail:
-    image: "ixdotai/smtp:v0.2.0"
+    image: "ixdotai/smtp:v0.5.1"
     volumes:
-      - ./files/dkim/config:/etc/exim4/_docker_additional_macros:ro
-      - ./files/dkim/rsa.private:/etc/exim4/domain.key:ro
+      - ./files/mail/rsa.private:/etc/exim4/dkim.key.temp:ro
     environment:
       - MAILNAME=${DOMAIN}
+      - DKIM_KEY_PATH=/etc/exim4/dkim.key.temp
     restart: always
   service:
     build:

--- a/files/dkim/config.disabled
+++ b/files/dkim/config.disabled
@@ -1,5 +1,0 @@
-DKIM_DOMAIN = ${lc:${domain:$h_from:}}
-DKIM_KEY_FILE = /etc/exim4/domain.key
-DKIM_PRIVATE_KEY = ${if exists{DKIM_KEY_FILE}{DKIM_KEY_FILE}{0}}
-DKIM_SELECTOR = dkim
-DKIM_CANON = simple


### PR DESCRIPTION
DKIM is essentially a requirement to get emails delivered, so my high-level goal is to make it easier to turn on, without having to risk merge conflicts. Some things that you should know about the SMTP container.

* It needs to have an existing file or the volume mapping will create an empty folder. That's why `rsa.empty` is there as a place holder in the compose file. It prevent that from happening.
* It expects the `rsa.private` file at `/etc/exim4/dkim.key.temp` so that's why that's hard coded in the compose file.
* It enables DKIM when `DKIM_KEY_PATH` has a value, so by default, we set it to empty, via `DKIM_CONTAINER_KEY` to disable it. Only when `DKIM_CONTAINER_KEY` has a value will DKIM be enabled. And the container expects this value to be the same as the container location of the mapped file, so that's why the .env has that value hard coded.
* config.disabled can be removed because those rules are now baked into the container.

I don't love how confusing this is, but it's the best I could think of. Open to feedback.

<!-- Please branch off and target the next branch unless you are only changing documentation like the readme. The master branch is a stable branch deployed in production. -->

#### What has been done to verify that this works as intended?

I confirmed that, after rebuild, emails send after removing `rsa.private` and `rsa.public` files and with the `DKIM_*` in the env file commented out. The emails are not DKIM enabled when they are received. 

I've also confirmed, after rebuild,  that emails send after adding `rsa.private`  and `rsa.public` files and with the `DKIM_*` enabled. The emails are DKIM enabled.

#### Why is this the best possible solution? Were any other approaches considered?

I considered just changing the permissions on `rsa.private` and leaving our implementation as is, but that's not as secure.

It could be nicer if the upstream container generated the keys. That'd simplify things, but it feels out of scope.

Honestly, we should consider removing this SMTP container entirely and ask that people use an upstream mail service. That's what Discourse, Ghost, etc, do.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

If you already have DKIM support, all you need to do is add values to .env and it should now work because the permissions will actually be correct. That said, I have not tried an upgrade. 

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

https://github.com/getodk/docs/pull/1655

#### Before submitting this PR, please make sure you have:

- [X] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced