### PR TITLE
Speed up stopping postgres14 container

### DIFF
--- a/files/postgres14/start-postgres.sh
+++ b/files/postgres14/start-postgres.sh
@@ -16,4 +16,4 @@ fi
 
 log "Starting postgres..."
 # call ENTRYPOINT + CMD from parent Docker image
-docker-entrypoint.sh postgres
+exec docker-entrypoint.sh postgres

--- a/postgres14.dockerfile
+++ b/postgres14.dockerfile
@@ -14,4 +14,4 @@ COPY files/postgres14/start-postgres.sh /usr/local/bin/
 ENV PGDATA /var/lib/odk/postgresql/14/data
 
 ENTRYPOINT []
-CMD start-postgres.sh
+CMD ["start-postgres.sh"]


### PR DESCRIPTION
Closes #419

<!-- Please branch off and target the next branch unless you are only changing documentation like the readme. The master branch is a stable branch deployed in production. -->

#### What has been done to verify that this works as intended?
```bash
docker compose build postgres14
docker compose up -d postgres14
docker compose stop
```

#### Why is this the best possible solution? Were any other approaches considered?
This is using all the same strategies as described in https://github.com/getodk/central/pull/417 I delayed this one because I didn't have a local setup at the time.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
As far as I know, there's no risk.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:

- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced