### PR TITLE
Use slim node images to reduce download and running size

### DIFF
--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -1,9 +1,16 @@
-FROM node:18.17 as intermediate
+FROM node:20.10-slim as intermediate
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        git \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY ./ ./
 RUN files/prebuild/write-version.sh
 ARG OIDC_ENABLED
 RUN OIDC_ENABLED="$OIDC_ENABLED" files/prebuild/build-frontend.sh
+
+
 
 # when upgrading, look for upstream changes to redirector.conf
 # also, confirm setup-odk.sh strips out HTTP-01 ACME challenge location

--- a/secrets.dockerfile
+++ b/secrets.dockerfile
@@ -1,2 +1,2 @@
-FROM node:18.17
+FROM node:20.10-slim
 COPY files/enketo/generate-secrets.sh ./

--- a/service.dockerfile
+++ b/service.dockerfile
@@ -1,30 +1,68 @@
-ARG node_version=18.17
-FROM node:${node_version} as intermediate
+ARG node_version=18
 
+
+
+FROM node:${node_version}-slim as pgdg
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        gpg \
+    && rm -rf /var/lib/apt/lists/* \
+    && update-ca-certificates
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(grep -oP 'VERSION_CODENAME=\K\w+' /etc/os-release)-pgdg main" \
+      | tee /etc/apt/sources.list.d/pgdg.list \
+    && curl https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+      | gpg --dearmor > /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg
+
+
+
+FROM node:${node_version}-slim as intermediate
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        git \
+    && rm -rf /var/lib/apt/lists/*
 COPY . .
 RUN mkdir /tmp/sentry-versions
 RUN git describe --tags --dirty > /tmp/sentry-versions/central
-WORKDIR server
+WORKDIR /server
 RUN git describe --tags --dirty > /tmp/sentry-versions/server
-WORKDIR ../client
+WORKDIR /client
 RUN git describe --tags --dirty > /tmp/sentry-versions/client
 
-FROM node:${node_version}
+
+
+FROM node:${node_version}-slim
+
+ARG node_version
+LABEL org.getodk.central.app-name="central" \
+      org.getodk.central.node-tag="${node_version}" \
+      org.getodk.central.maintainer="admin@hotosm.org" \
+      org.getodk.central.port="8383"
 
 WORKDIR /usr/odk
 
-RUN apt-get update && apt-get install wait-for-it && rm -rf /var/lib/apt/lists/*
-
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(grep -oP 'VERSION_CODENAME=\K\w+' /etc/os-release)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list && \
-  curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg && \
-  apt-get update && \
-  apt-get install -y cron gettext postgresql-client-14
+COPY --from=pgdg /etc/apt/sources.list.d/pgdg.list \
+    /etc/apt/sources.list.d/pgdg.list
+COPY --from=pgdg /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg \
+    /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        gpg \
+        cron \
+        wait-for-it \
+        gettext \
+        procps \
+        postgresql-client-14 \
+        netcat-traditional \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY files/service/crontab /etc/cron.d/odk
 
 COPY server/package*.json ./
 
-RUN npm clean-install --omit=dev --legacy-peer-deps --no-audit --fund=false --update-notifier=false
+RUN npm clean-install --omit=dev --legacy-peer-deps --no-audit \
+        --fund=false --update-notifier=false
 
 COPY server/ ./
 COPY files/service/scripts/ ./
@@ -34,5 +72,5 @@ COPY files/service/odk-cmd /usr/bin/
 
 COPY --from=intermediate /tmp/sentry-versions/ ./sentry-versions
 
-EXPOSE 8383
-
+HEALTHCHECK --start-period=10s --interval=5s --retries=10 \
+    CMD nc -z localhost 8383 || exit 1

--- a/service.dockerfile
+++ b/service.dockerfile
@@ -35,9 +35,7 @@ RUN git describe --tags --dirty > /tmp/sentry-versions/client
 FROM node:${node_version}-slim
 
 ARG node_version
-LABEL org.opencontainers.image.title="ODK Central backend" \
-      org.opencontainers.image.vendor="ODK" \
-      org.opencontainers.image.source="https://github.com/getodk/central"
+LABEL org.opencontainers.image.source="https://github.com/getodk/central"
 
 WORKDIR /usr/odk
 

--- a/service.dockerfile
+++ b/service.dockerfile
@@ -37,7 +37,7 @@ FROM node:${node_version}-slim
 ARG node_version
 LABEL org.getodk.central.app-name="central" \
       org.getodk.central.node-tag="${node_version}" \
-      org.getodk.central.maintainer="admin@hotosm.org" \
+      org.getodk.central.maintainer="support@getodk.org" \
       org.getodk.central.port="8383"
 
 WORKDIR /usr/odk
@@ -68,6 +68,3 @@ COPY files/service/crontab /etc/cron.d/odk
 COPY files/service/odk-cmd /usr/bin/
 
 COPY --from=intermediate /tmp/sentry-versions/ ./sentry-versions
-
-HEALTHCHECK --start-period=10s --interval=5s --retries=10 \
-    CMD nc -z localhost 8383 || exit 1

--- a/service.dockerfile
+++ b/service.dockerfile
@@ -1,4 +1,4 @@
-ARG node_version=18.17
+ARG node_version=20.10
 
 
 

--- a/service.dockerfile
+++ b/service.dockerfile
@@ -1,4 +1,4 @@
-ARG node_version=18
+ARG node_version=18.17
 
 
 

--- a/service.dockerfile
+++ b/service.dockerfile
@@ -42,6 +42,7 @@ LABEL org.getodk.central.app-name="central" \
 
 WORKDIR /usr/odk
 
+COPY server/package*.json ./
 COPY --from=pgdg /etc/apt/sources.list.d/pgdg.list \
     /etc/apt/sources.list.d/pgdg.list
 COPY --from=pgdg /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg \
@@ -55,19 +56,15 @@ RUN apt-get update \
         procps \
         postgresql-client-14 \
         netcat-traditional \
-    && rm -rf /var/lib/apt/lists/*
-
-COPY files/service/crontab /etc/cron.d/odk
-
-COPY server/package*.json ./
-
-RUN npm clean-install --omit=dev --legacy-peer-deps --no-audit \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm clean-install --omit=dev --legacy-peer-deps --no-audit \
         --fund=false --update-notifier=false
 
 COPY server/ ./
 COPY files/service/scripts/ ./
 
 COPY files/service/config.json.template /usr/share/odk/
+COPY files/service/crontab /etc/cron.d/odk
 COPY files/service/odk-cmd /usr/bin/
 
 COPY --from=intermediate /tmp/sentry-versions/ ./sentry-versions

--- a/service.dockerfile
+++ b/service.dockerfile
@@ -35,10 +35,9 @@ RUN git describe --tags --dirty > /tmp/sentry-versions/client
 FROM node:${node_version}-slim
 
 ARG node_version
-LABEL org.getodk.central.app-name="central" \
-      org.getodk.central.node-tag="${node_version}" \
-      org.getodk.central.maintainer="support@getodk.org" \
-      org.getodk.central.port="8383"
+LABEL org.opencontainers.image.title="ODK Central backend" \
+      org.opencontainers.image.vendor="ODK" \
+      org.opencontainers.image.source="https://github.com/getodk/central"
 
 WORKDIR /usr/odk
 
@@ -68,3 +67,5 @@ COPY files/service/crontab /etc/cron.d/odk
 COPY files/service/odk-cmd /usr/bin/
 
 COPY --from=intermediate /tmp/sentry-versions/ ./sentry-versions
+
+EXPOSE 8383


### PR DESCRIPTION
## Includes

- Built using `node:18-slim` instead of `node:18.17`.
  - I assumed we probably want patch versions of node that shouldn't be breaking.
  - Is the assumption correct, or should I change back to pinned `18.17`?
- Merged RUN directives where possible
  - This was less significant than I thought, maybe 50 - 100 MB saving.
  - The dockerfile was missing a cleanup of the apt list here too: https://github.com/getodk/central/blob/774b491961578bd6e03ceaa6cf8032dd27b828a7/service.dockerfile#L21-L22
- Absolute paths for WORKDIR (as per dockerfile-utils linting).
- Add HEALTHCHECK. This is useful for docker-compose setups. It's ignored in Kubernetes.
- Remove deprecated EXPOSE command and replace with LABELs.

## Discussion

I image the reason for not using a slim image originally is because they don't have git installed for the
`git describe --tags --dirty` command. Solved with multi-stage.

This PR was originally discussed as part of #519.
Reducing the space required to build images may be useful on systems with very limited space.
However, the gains that can be made are rather small considering >1 GB of cached images shouldn't really be a problem for most.

There have been discussions around providing pre-built images and an open PR to facilitate this, so this discussion will be moot if that is merged.

There is always a tradeoff between cache image bloat and dockerfile readability.
However, in this example I personally think the original is much more readable:

```dockerfile
FROM node:${node_version}-slim as intermediate
RUN apt-get update \
    && apt-get install -y --no-install-recommends \
        git \
    && rm -rf /var/lib/apt/lists/*
COPY . .
RUN mkdir /tmp/sentry-versions
RUN git describe --tags --dirty > /tmp/sentry-versions/central
WORKDIR /server
RUN git describe --tags --dirty > /tmp/sentry-versions/server
WORKDIR /client
RUN git describe --tags --dirty > /tmp/sentry-versions/client
```

compared to less readable & not best practice of `cd` in dockerfiles (for little gain):

```dockerfile
FROM node:${node_version}-slim as intermediate
COPY . .
RUN apt-get update \
    && apt-get install -y --no-install-recommends \
        git \
    && rm -rf /var/lib/apt/lists/* \
    && mkdir /tmp/sentry-versions \
    && git describe --tags --dirty > /tmp/sentry-versions/central \
    && cd server && git describe --tags --dirty > /tmp/sentry-versions/server \
    && cd ../client && git describe --tags --dirty > /tmp/sentry-versions/client
```

> Note that this is not the final build stage, so the discussion is about image cache bloat,
> not intermediate image layer size.