### PR TITLE
Upgrade to nginx-1.25.4

### DIFF
--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -14,7 +14,7 @@ RUN OIDC_ENABLED="$OIDC_ENABLED" files/prebuild/build-frontend.sh
 
 # when upgrading, look for upstream changes to redirector.conf
 # also, confirm setup-odk.sh strips out HTTP-01 ACME challenge location
-FROM jonasal/nginx-certbot:5.0.0
+FROM jonasal/nginx-certbot:5.0.1-nginx1.25.4
 
 EXPOSE 80
 EXPOSE 443


### PR DESCRIPTION
Address CVE-2024-24989 and CVE-2024-24990.

I confirmed that our nginx was built with`--with-http_v3_module` so this module is there, but we don't enable it in the conf so I don't think (but I'm not sure) we are vulnerable. 

#### What has been done to verify that this works as intended?
Reviewed diffs at https://github.com/JonasAlfredsson/docker-nginx-certbot/compare/v5.0.0...v5.0.1-nginx1.25.4 for anything troubling. I don't see anything.

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
