### PR TITLE
Check if running container was launched with compose v1

### DIFF
--- a/files/postgres14/upgrade/check-available-space
+++ b/files/postgres14/upgrade/check-available-space
@@ -17,7 +17,7 @@ free="$(df --output=avail "$dockerRootDir/volumes" | tail -n+2)"
 
 # Support both Docker Compose v1 & v2 container names.
 # See: https://docs.docker.com/compose/migrate/#service-container-names
-if ! docker compose version >/dev/null 2>/dev/null; then
+if docker ps -a --format '{{.Names}}' | grep -q "central_postgres_1"; then
   containerName="central_postgres_1"
 else
   containerName="central-postgres-1"


### PR DESCRIPTION
As shown at https://forum.getodk.org/t/how-to-upgrade-central-from-v1-5-3-to-latest/45797/10

The check disk command doesn't work because even if you have compose v2 installed, if the container was launched with v1, it will have underscores in the name. This patch checks to see if there is a running container with underscores and returns a 1 or 0.

I haven't tested this on a real system, but I have verified the individual docker and grep commands work as expected.