### PR TITLE
Leaving version in docker-compose results in warning

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   postgres14:
     build:


### PR DESCRIPTION
Recent versions of Docker will show a warning if there is a version key. Removing the key fixes the problem.

<img width="548" alt="Screenshot 2024-04-15 at 14 56 35" src="https://github.com/getodk/central/assets/32369/62e3fdd6-f0ee-4c03-9955-939ec6a31eb3">
