### PR TITLE
Generate Frontend config and serve it

### DIFF
--- a/files/nginx/client-config.json.template
+++ b/files/nginx/client-config.json.template
@@ -1,0 +1,3 @@
+{
+  "oidcEnabled": $OIDC_ENABLED
+}

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -67,6 +67,10 @@ server {
       include /usr/share/odk/nginx/common-headers.conf;
       add_header Cache-Control no-cache;
     }
+    location /client-config.json {
+      include /usr/share/odk/nginx/common-headers.conf;
+      add_header Cache-Control no-cache;
+    }
     location /index.html {
       include /usr/share/odk/nginx/common-headers.conf;
       add_header Cache-Control no-cache;

--- a/files/prebuild/build-frontend.sh
+++ b/files/prebuild/build-frontend.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -eu
 cd client
 npm clean-install --no-audit --fund=false --update-notifier=false
-VUE_APP_OIDC_ENABLED="$OIDC_ENABLED" npm run build
+npm run build

--- a/files/prebuild/write-client-config.sh
+++ b/files/prebuild/write-client-config.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -eu
+set -o pipefail
+
+if [[ $OIDC_ENABLED != 'true' ]] && [[ $OIDC_ENABLED != 'false' ]]; then
+  echo 'OIDC_ENABLED must be either true or false'
+  exit 1
+fi
+
+envsubst < files/nginx/client-config.json.template > /tmp/client-config.json

--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -8,9 +8,9 @@ RUN apt-get update \
 
 COPY ./ ./
 RUN files/prebuild/write-version.sh
-ARG OIDC_ENABLED
-RUN envsubst < files/nginx/client-config.json.template > /tmp/client-config.json
 RUN files/prebuild/build-frontend.sh
+ARG OIDC_ENABLED
+RUN files/prebuild/write-client-config.sh
 
 
 

--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -3,12 +3,14 @@ FROM node:20.12.2-slim as intermediate
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         git \
+        gettext-base \
     && rm -rf /var/lib/apt/lists/*
 
 COPY ./ ./
 RUN files/prebuild/write-version.sh
 ARG OIDC_ENABLED
-RUN OIDC_ENABLED="$OIDC_ENABLED" files/prebuild/build-frontend.sh
+RUN envsubst < files/nginx/client-config.json.template > /tmp/client-config.json
+RUN files/prebuild/build-frontend.sh
 
 
 
@@ -32,3 +34,4 @@ COPY files/nginx/*.conf* /usr/share/odk/nginx/
 
 COPY --from=intermediate client/dist/ /usr/share/nginx/html
 COPY --from=intermediate /tmp/version.txt /usr/share/nginx/html
+COPY --from=intermediate /tmp/client-config.json /usr/share/nginx/html


### PR DESCRIPTION
This PR makes progress on getodk/central#656. It generates the Frontend config and serves it so that Frontend can then fetch it. The corresponding Frontend PR is getodk/central-frontend#988.

#### What has been done to verify that this works as intended?

So far just that CI passes. Once it's on staging, I can double-check that /client-config.json is served correctly.

#### Why is this the best possible solution? Were any other approaches considered?

I'm going to leave comments about a few lines.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

getodk/central-frontend#988 mentions the cost of an additional request. I don't think it will be much of an issue.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
