### PR TITLE
Update image used for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2004:current
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,4 +37,9 @@ jobs:
               appropriate/curl -4 --insecure --retry 20 --retry-delay 2 --retry-connrefused https://localhost/v1/projects \
               | tee /dev/tty \
               | grep -q '\[\]'
-            docker compose exec -T service npx pm2 list | grep -c "online" | grep -q 4 || exit 1
+      - run:
+          name: Verify pm2
+          command: |
+            docker compose exec -T service npx pm2 list \
+              | tee /dev/tty \
+              | grep -c "online" | grep -q 4


### PR DESCRIPTION
When I view a build in CircleCI, I see the following warning (e.g., [here](https://app.circleci.com/pipelines/github/getodk/central/927/workflows/cdc558cb-6857-419e-9fc2-b555b2069a07/jobs/972)):

> This job is using a [deprecated](https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/) image 'ubuntu-2004:202201-02', please update to a newer image

This PR resolves the warning by updating the image.

#### What has been done to verify that this works as intended?

CircleCI continues to pass.

#### Why is this the best possible solution? Were any other approaches considered?

This PR targets the current version of Ubuntu 20.04. If we were concerned that we might introduce something to Central that would work in a new version of Ubuntu 20.04, but not an older one, we could intentionally target an older version. It looks like one of the [options](https://circleci.com/docs/linux-vm-support-policy/) is `previous`, which is 3–6 months old, though I think that's Ubuntu 22.04. That link says, "We recommend using the `default` version and not pinning to a date version." The list of images available for Ubuntu 20.04 is [here](https://circleci.com/developer/machine/image/ubuntu-2004).

Relatedly, I saw that Ubuntu 20.04 will reach EOL in 2025. With that in mind, I tried specifying `image: default`. It looks like that's currently `ubuntu-2204:2024.04.4`. However, when I do so, CircleCI [fails](https://app.circleci.com/pipelines/github/getodk/central/929/workflows/38d6cca0-f985-43d1-a37a-eec98c8b9cc4/jobs/974). From a glance, it looks like pm2 isn't working as expected. That sounds like it could be an issue worth looking into. I'm not able to do so at this particular moment, but I'd be happy to file an issue about it if that'd be helpful.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
