### PR TITLE
Add workflow to publish nginx and service images to GHCR

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -1,6 +1,10 @@
 name: GHCR
 
-on: push
+on:
+  workflow_dispatch:
+  push:
+    branches: [master]
+    tags: ["v*.*.*"]
 
 env:
   REGISTRY: ghcr.io
@@ -40,7 +44,7 @@ jobs:
       - name: Set up QEMU emulator for multi-arch images
         uses: docker/setup-qemu-action@v3
 
-      - name: Set up Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push ${{ matrix.image }} Docker image

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -1,0 +1,47 @@
+name: GHCR
+
+on: push
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      matrix:
+        image: [nginx, service]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          submodules: recursive
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/central-${{ matrix.image }}
+
+      - name: Build and push ${{ matrix.image }} Docker image
+        uses: docker/build-push-action@v5
+        with:
+            file: ${{ matrix.image }}.dockerfile
+            context: .
+            push: true
+            tags: ${{ steps.meta.outputs.tags }}
+            labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -37,6 +37,12 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/central-${{ matrix.image }}
 
+      - name: Set up QEMU emulator for multi-arch images
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push ${{ matrix.image }} Docker image
         uses: docker/build-push-action@v5
         with:
@@ -45,3 +51,4 @@ jobs:
             push: true
             tags: ${{ steps.meta.outputs.tags }}
             labels: ${{ steps.meta.outputs.labels }}
+            platforms: 'linux/amd64,linux/arm64'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,8 +77,6 @@ services:
   nginx:
     build:
       context: .
-      args:
-        - OIDC_ENABLED=${OIDC_ENABLED:-false}
       dockerfile: nginx.dockerfile
     depends_on:
       - service
@@ -90,6 +88,13 @@ services:
       - SENTRY_ORG_SUBDOMAIN=${SENTRY_ORG_SUBDOMAIN:-o130137}
       - SENTRY_KEY=${SENTRY_KEY:-3cf75f54983e473da6bd07daddf0d2ee}
       - SENTRY_PROJECT=${SENTRY_PROJECT:-1298632}
+      - OIDC_ENABLED=${OIDC_ENABLED:-false}
+    volumes:
+      - ./files/local/customssl/:/etc/customssl/live/local/
+      - ./files/nginx/redirector.conf:/etc/nginx/conf.d/redirector.conf
+      - ./files/nginx/common-headers.conf:/usr/share/odk/nginx/common-headers.conf
+      - ./files/nginx/odk.conf.template:/usr/share/odk/nginx/odk.conf.template
+      - ./files/nginx/client-config.json.template:/usr/share/odk/nginx/client-config.json.template
     ports:
       - "${HTTP_PORT:-80}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,11 +90,11 @@ services:
       - SENTRY_PROJECT=${SENTRY_PROJECT:-1298632}
       - OIDC_ENABLED=${OIDC_ENABLED:-false}
     volumes:
-      - ./files/local/customssl/:/etc/customssl/live/local/
-      - ./files/nginx/redirector.conf:/etc/nginx/conf.d/redirector.conf
-      - ./files/nginx/common-headers.conf:/usr/share/odk/nginx/common-headers.conf
-      - ./files/nginx/odk.conf.template:/usr/share/odk/nginx/odk.conf.template
-      - ./files/nginx/client-config.json.template:/usr/share/odk/nginx/client-config.json.template
+      - ./files/local/customssl/:/etc/customssl/live/local/:ro
+      - ./files/nginx/redirector.conf:/etc/nginx/conf.d/redirector.conf:ro
+      - ./files/nginx/common-headers.conf:/usr/share/odk/nginx/common-headers.conf:ro
+      - ./files/nginx/odk.conf.template:/usr/share/odk/nginx/odk.conf.template:ro
+      - ./files/nginx/client-config.json.template:/usr/share/odk/nginx/client-config.json.template:ro
     ports:
       - "${HTTP_PORT:-80}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,8 +91,6 @@ services:
       - OIDC_ENABLED=${OIDC_ENABLED:-false}
     volumes:
       - ./files/local/customssl/:/etc/customssl/live/local/:ro
-      - ./files/nginx/redirector.conf:/etc/nginx/conf.d/redirector.conf:ro
-      - ./files/nginx/common-headers.conf:/usr/share/odk/nginx/common-headers.conf:ro
       - ./files/nginx/odk.conf.template:/usr/share/odk/nginx/odk.conf.template:ro
       - ./files/nginx/client-config.json.template:/usr/share/odk/nginx/client-config.json.template:ro
     ports:

--- a/files/nginx/setup-odk.sh
+++ b/files/nginx/setup-odk.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+
+echo "writing client config..."
+if [[ $OIDC_ENABLED != 'true' ]] && [[ $OIDC_ENABLED != 'false' ]]; then
+  echo 'OIDC_ENABLED must be either true or false'
+  exit 1
+fi
+
+envsubst < /usr/share/odk/nginx/client-config.json.template > /usr/share/nginx/html/client-config.json
+
+
 DH_PATH=/etc/dh/nginx.pem
 if [ "$SSL_TYPE" != "upstream" ] && [ ! -s "$DH_PATH" ]; then
   openssl dhparam -out "$DH_PATH" 2048
@@ -17,7 +27,6 @@ fi
 
 # start from fresh templates in case ssl type has changed
 echo "writing fresh nginx templates..."
-cp /usr/share/odk/nginx/redirector.conf /etc/nginx/conf.d/redirector.conf
 CNAME=$( [ "$SSL_TYPE" = "customssl" ] && echo "local" || echo "$DOMAIN") \
 envsubst '$SSL_TYPE $CNAME $SENTRY_ORG_SUBDOMAIN $SENTRY_KEY $SENTRY_PROJECT' \
   < /usr/share/odk/nginx/odk.conf.template \

--- a/files/nginx/setup-odk.sh
+++ b/files/nginx/setup-odk.sh
@@ -27,6 +27,9 @@ fi
 
 # start from fresh templates in case ssl type has changed
 echo "writing fresh nginx templates..."
+# redirector.conf gets deleted if using upstream SSL so copy it back
+cp /usr/share/odk/nginx/redirector.conf /etc/nginx/conf.d/redirector.conf
+
 CNAME=$( [ "$SSL_TYPE" = "customssl" ] && echo "local" || echo "$DOMAIN") \
 envsubst '$SSL_TYPE $CNAME $SENTRY_ORG_SUBDOMAIN $SENTRY_KEY $SENTRY_PROJECT' \
   < /usr/share/odk/nginx/odk.conf.template \

--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -19,7 +19,8 @@ FROM jonasal/nginx-certbot:5.0.1
 EXPOSE 80
 EXPOSE 443
 
-VOLUME [ "/etc/dh", "/etc/selfsign", "/etc/nginx/conf.d" ]
+# Persist Diffie-Hellman parameters and/or selfsign key
+VOLUME [ "/etc/dh", "/etc/selfsign" ]
 
 RUN apt-get update && apt-get install -y netcat-openbsd
 
@@ -30,4 +31,4 @@ COPY files/nginx/setup-odk.sh /scripts/
 COPY --from=intermediate client/dist/ /usr/share/nginx/html
 COPY --from=intermediate /tmp/version.txt /usr/share/nginx/html
 
-CMD [ "/bin/bash", "/scripts/setup-odk.sh" ]
+ENTRYPOINT [ "/scripts/setup-odk.sh" ]

--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update && apt-get install -y netcat-openbsd
 RUN mkdir -p /usr/share/odk/nginx/
 
 COPY files/nginx/setup-odk.sh /scripts/
+RUN chmod +x /scripts/setup-odk.sh
 
 COPY --from=intermediate client/dist/ /usr/share/nginx/html
 COPY --from=intermediate /tmp/version.txt /usr/share/nginx/html

--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -29,6 +29,9 @@ RUN mkdir -p /usr/share/odk/nginx/
 COPY files/nginx/setup-odk.sh /scripts/
 RUN chmod +x /scripts/setup-odk.sh
 
+COPY files/nginx/redirector.conf /usr/share/odk/nginx/
+COPY files/nginx/common-headers.conf /usr/share/odk/nginx/
+
 COPY --from=intermediate client/dist/ /usr/share/nginx/html
 COPY --from=intermediate /tmp/version.txt /usr/share/nginx/html
 

--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -9,8 +9,6 @@ RUN apt-get update \
 COPY ./ ./
 RUN files/prebuild/write-version.sh
 RUN files/prebuild/build-frontend.sh
-ARG OIDC_ENABLED
-RUN files/prebuild/write-client-config.sh
 
 
 
@@ -22,16 +20,14 @@ EXPOSE 80
 EXPOSE 443
 
 VOLUME [ "/etc/dh", "/etc/selfsign", "/etc/nginx/conf.d" ]
-ENTRYPOINT [ "/bin/bash", "/scripts/setup-odk.sh" ]
 
 RUN apt-get update && apt-get install -y netcat-openbsd
 
 RUN mkdir -p /usr/share/odk/nginx/
 
 COPY files/nginx/setup-odk.sh /scripts/
-COPY files/local/customssl/*.pem /etc/customssl/live/local/
-COPY files/nginx/*.conf* /usr/share/odk/nginx/
 
 COPY --from=intermediate client/dist/ /usr/share/nginx/html
 COPY --from=intermediate /tmp/version.txt /usr/share/nginx/html
-COPY --from=intermediate /tmp/client-config.json /usr/share/nginx/html
+
+CMD [ "/bin/bash", "/scripts/setup-odk.sh" ]


### PR DESCRIPTION
Closes #165
Progress towards https://github.com/getodk/central/issues/656

Based on #249, https://github.com/getodk/central/pull/546

TODO:
- [x] Support custom SSL
- [x] Template client config at run time
- [x] Verify nginx image with Let's Encrypt certs
- [x] Verify client config with OIDC on (requires using https://github.com/getodk/central-frontend/pull/988)
- [x] Support [arm64](https://github.com/getodk/central/pull/676#issuecomment-2187913532)
- [x] Publish on master tag and manual trigger

#### What has been done to verify that this works as intended?
The built images can be seen at https://github.com/lognaturel/central/pkgs/container/central-nginx and https://github.com/lognaturel/central/pkgs/container/central-service

I have verified that the service image + nginx image with custom certs work with the standard Docker Compose file.

#### Why is this the best possible solution? Were any other approaches considered?
I mostly followed the groundwork laid by @mattelacchiato in #249 and then @tobiasmcnulty at #546 with some further simplifications.

I used the image naming suggested by @tobiasmcnulty: `central-service` and `central-nginx`. I considered calling them frontend and backend but I think matching the Dockerfile names is the least confusing option.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

It doesn't affect users yet because the images aren't used. I'm proposing splitting that off at https://github.com/getodk/central/issues/677

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

Not yet but https://github.com/getodk/central/issues/677 will.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
