### PR TITLE
Use pre-built images

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -3,8 +3,11 @@ name: GHCR
 on:
   workflow_dispatch:
   push:
-    branches: [master]
-    tags: ["v*.*.*"]
+    branches:
+      - next
+      - use-images
+    tags:
+      - v*.*.*
 
 env:
   REGISTRY: ghcr.io

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,9 +34,7 @@ services:
       - DKIM_KEY_PATH=/etc/exim4/dkim.key.temp
     restart: always
   service:
-    build:
-      context: .
-      dockerfile: service.dockerfile
+    image: 'ghcr.io/getodk/central-service:use-images'
     depends_on:
       - secrets
       - postgres14
@@ -75,9 +73,7 @@ services:
     logging:
       driver: local
   nginx:
-    build:
-      context: .
-      dockerfile: nginx.dockerfile
+    image: 'ghcr.io/getodk/central-nginx:use-images'
     depends_on:
       - service
       - enketo


### PR DESCRIPTION
Closes #677

There's an ordering problem that I can't quite wrap my brain around. Let's say we want to tag v2024.2.0. That means we want to produce `central-service` with version `v2024.2.0` and `central-nginx` with version `v2024.2.0` AND we want to use those tags in the Docker compose file. So far the only process I can think of is to put in a commit that bumps the versions in Docker compose that will fail CI, tag (which will build the images), then run CircleCI again to actually test with the new images

This would be slightly less bad if we could guarantee that the Circle CI tasks ran after the image building. I think to do that we might need to move those tasks to Github?

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
