### PR TITLE
Crontab job for force processing submission backlog of offline entities

### DIFF
--- a/files/service/crontab
+++ b/files/service/crontab
@@ -1,3 +1,4 @@
 0 4 * * * root /usr/odk/purge-forms.sh
 0 3 * * * root /usr/odk/run-analytics.sh
+0 2 * * * root /usr/odk/process-backlog.sh
 0 1 * * 0 root /usr/odk/reap-sessions.sh

--- a/files/service/scripts/process-backlog.sh
+++ b/files/service/scripts/process-backlog.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -eu
+
+cd /usr/odk
+/usr/local/bin/node lib/bin/process-backlog.js >/proc/1/fd/1 2>/proc/1/fd/2
+


### PR DESCRIPTION
Related to backend PR https://github.com/getodk/central-backend/pull/1172

I decided to run this at 2am. We used to do backups then, but that seems to have been removed from the crontab. This shouldn't interfere with running the purge command later because force processing things in the backlog will safely work around soft-deleted forms/submissions the same as purged submissions.

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
