### PR TITLE
Dockerfiles: make keyword case consistent

### DIFF
--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.12.2-slim as intermediate
+FROM node:20.12.2-slim AS intermediate
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/service.dockerfile
+++ b/service.dockerfile
@@ -2,7 +2,7 @@ ARG node_version=20.12.2
 
 
 
-FROM node:${node_version}-slim as pgdg
+FROM node:${node_version}-slim AS pgdg
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
@@ -17,7 +17,7 @@ RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(grep -oP 'VERSION_CODEN
 
 
 
-FROM node:${node_version}-slim as intermediate
+FROM node:${node_version}-slim AS intermediate
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         git \


### PR DESCRIPTION
Resolves warnings:

    - FromAsCasing: 'as' and 'FROM' keywords' casing do not match
