### PR TITLE
Remove write-client-config.sh

### DIFF
--- a/files/prebuild/write-client-config.sh
+++ b/files/prebuild/write-client-config.sh
@@ -1,9 +1,0 @@
-#!/bin/bash -eu
-set -o pipefail
-
-if [[ $OIDC_ENABLED != 'true' ]] && [[ $OIDC_ENABLED != 'false' ]]; then
-  echo 'OIDC_ENABLED must be either true or false'
-  exit 1
-fi
-
-envsubst < files/nginx/client-config.json.template > /tmp/client-config.json


### PR DESCRIPTION
I don't see anything running write-client-config.sh, so I think it's safe to remove that file. It looks like #676 added the code in write-client-config.sh to another file, so doesn't run the script anymore.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced