### PR TITLE
ci: don't fail log-output steps

### DIFF
--- a/.github/workflows/test-nginx.yml
+++ b/.github/workflows/test-nginx.yml
@@ -17,8 +17,8 @@ jobs:
     - run: cd test && ./run-tests.sh
 
     - if: always()
-      run: docker logs test-nginx-1
+      run: docker logs test-nginx-1 || true
     - if: always()
-      run: docker logs test-service-1
+      run: docker logs test-service-1 || true
     - if: always()
-      run: docker logs test-enketo-1
+      run: docker logs test-enketo-1 || true


### PR DESCRIPTION
Don't fail log output build steps if the corresponding docker image never started, e.g.

    Error response from daemon: No such container: test-enketo-1

This makes the github actions GUI less confusing and quicker to navigate to the real build failure.
