### PR TITLE
nginx-tests: remove unnecessary res.ok assertions

### DIFF
--- a/test/test-nginx.js
+++ b/test/test-nginx.js
@@ -11,7 +11,6 @@ describe('nginx config', () => {
     const res = await fetchHttp('/.well-known/acme-challenge');
 
     // then
-    assert.isFalse(res.ok);
     assert.equal(res.status, 301);
     assert.equal(res.headers.get('location'), 'https://localhost:9000/.well-known/acme-challenge');
   });
@@ -21,7 +20,6 @@ describe('nginx config', () => {
     const res = await fetchHttps('/.well-known/acme-challenge');
 
     // then
-    assert.isFalse(res.ok);
     assert.equal(res.status, 404);
   });
 
@@ -30,7 +28,6 @@ describe('nginx config', () => {
     const res = await fetchHttp('/');
 
     // then
-    assert.isFalse(res.ok);
     assert.equal(res.status, 301);
     assert.equal(res.headers.get('location'), 'https://localhost:9000/');
   });
@@ -40,7 +37,6 @@ describe('nginx config', () => {
     const res = await fetchHttps('/client-config.json');
 
     // then
-    assert.isTrue(res.ok);
     assert.equal(res.status, 200);
     assert.deepEqual(await res.json(), { oidcEnabled: false });
     assert.equal(await res.headers.get('cache-control'), 'no-cache');
@@ -55,7 +51,6 @@ describe('nginx config', () => {
       const res = await fetchHttps(staticFile);
 
       // then
-      assert.isTrue(res.ok);
       assert.equal(res.status, 200);
       assert.equal(await res.text(), `hi:${staticFile}\n`);
       assert.equal(await res.headers.get('cache-control'), 'no-cache');
@@ -70,7 +65,6 @@ describe('nginx config', () => {
       const res = await fetchHttps(staticFile);
 
       // then
-      assert.isTrue(res.ok);
       assert.equal(res.status, 200);
       assert.equal(await res.text(), `hi:${staticFile}\n`);
       assert.isNull(await res.headers.get('cache-control'));
@@ -82,7 +76,6 @@ describe('nginx config', () => {
     const res = await fetchHttps('/-/some/enketo/path');
 
     // then
-    assert.isTrue(res.ok);
     assert.equal(res.status, 200);
     assert.equal(await res.text(), 'OK');
     // and
@@ -96,7 +89,6 @@ describe('nginx config', () => {
     const res = await fetchHttps('/v1/some/central-backend/path');
 
     // then
-    assert.isTrue(res.ok);
     assert.equal(res.status, 200);
     assert.equal(await res.text(), 'OK');
     // and


### PR DESCRIPTION
These assertions are followed by more specific assertions on res.status, which provide more helpful error messages on failure.
