### PR TITLE
test-nginx: assert x-forwarded-proto header is always https

### DIFF
--- a/test/mock-http-server/index.js
+++ b/test/mock-http-server/index.js
@@ -14,6 +14,8 @@ app.get('/reset',       withStdLogging((req, res) => {
   res.json('OK');
 }));
 
+app.get('/v1/reflect-headers', withStdLogging((req, res) => res.json(req.headers)));
+
 app.get('/*', ok('GET'));
 app.post('/*', ok('POST'));
 // TODO add more methods as required

--- a/test/test-nginx.js
+++ b/test/test-nginx.js
@@ -107,7 +107,6 @@ describe('nginx config', () => {
     // when
     const body = await res.json();
     // then
-    console.log('body:', body);
     assert.equal(body['x-forwarded-proto'], 'https');
   });
 
@@ -125,7 +124,6 @@ describe('nginx config', () => {
     // when
     const body = await res.json();
     // then
-    console.log('body:', body);
     assert.equal(body['x-forwarded-proto'], 'https');
   });
 });

--- a/test/test-nginx.js
+++ b/test/test-nginx.js
@@ -100,7 +100,6 @@ describe('nginx config', () => {
   it('should set x-forwarded-proto header to "https"', async () => {
     // when
     const res = await fetch(`https://localhost:9001/v1/reflect-headers`);
-
     // then
     assert.equal(res.status, 200);
 
@@ -117,7 +116,6 @@ describe('nginx config', () => {
         'x-forwarded-proto': 'http',
       },
     });
-
     // then
     assert.equal(res.status, 200);
 

--- a/test/test-nginx.js
+++ b/test/test-nginx.js
@@ -104,6 +104,38 @@ describe('nginx config', () => {
       { method:'GET', path:'/v1/some/central-backend/path' },
     );
   });
+
+  it('should set x-forwarded-proto header to "https"', async () => {
+    // when
+    const res = await fetch(`https://localhost:9001/v1/reflect-headers`);
+
+    // then
+    assert.equal(res.status, 200);
+
+    // when
+    const body = await res.json();
+    // then
+    console.log('body:', body);
+    assert.equal(body['x-forwarded-proto'], 'https');
+  });
+
+  it('should override supplied x-forwarded-proto header', async () => {
+    // when
+    const res = await fetch(`https://localhost:9001/v1/reflect-headers`, {
+      headers: {
+        'x-forwarded-proto': 'http',
+      },
+    });
+
+    // then
+    assert.equal(res.status, 200);
+
+    // when
+    const body = await res.json();
+    // then
+    console.log('body:', body);
+    assert.equal(body['x-forwarded-proto'], 'https');
+  });
 });
 
 function fetchHttp(path, options) {


### PR DESCRIPTION
This header's value is relied on in both central-backend and enketo.