### PR TITLE
test/nginx: remove letsencrypt-specific tests

### DIFF
--- a/test/test-nginx.js
+++ b/test/test-nginx.js
@@ -6,23 +6,6 @@ describe('nginx config', () => {
     resetBackendMock(),
   ]));
 
-  it('well-known should serve from HTTP', async () => {
-    // when
-    const res = await fetchHttp('/.well-known/acme-challenge');
-
-    // then
-    assert.equal(res.status, 301);
-    assert.equal(res.headers.get('location'), 'https://localhost:9000/.well-known/acme-challenge');
-  });
-
-  it('well-known should serve from HTTPS', async () => {
-    // when
-    const res = await fetchHttps('/.well-known/acme-challenge');
-
-    // then
-    assert.equal(res.status, 404);
-  });
-
   it('HTTP should forward to HTTPS', async () => {
     // when
     const res = await fetchHttp('/');


### PR DESCRIPTION
* /.well-known/acme-challenge path isn't relevant to these tests, as they do not use letsencrypt SSL certs
* in the test scenario, specific handling for /.well-known/acme-challenge is removed from redirector.conf in files/nginx/setup-odk.sh
* the tests don't make sense, as they're checking for 404s