### PR TITLE
Update pyxform to fix geojson support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,7 +108,7 @@ services:
       options:
         max-file: "30"
   pyxform:
-    image: 'ghcr.io/getodk/pyxform-http:v2.1.0'
+    image: 'ghcr.io/getodk/pyxform-http:v2.1.1'
     restart: always
   secrets:
     volumes:


### PR DESCRIPTION
Closes #

#### What has been done to verify that this works as intended?
Made docker-compose change on dev, verified I can convert a form with geojson attachment.

#### Why is this the best possible solution? Were any other approaches considered?
This fix comes in Validate where we've added the jackson dependency back in. Ideally we would not need it but for now this fix brings back broken functionality.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Should just fix geojson support. That's all that's changed across the stack.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
