### PR TITLE
nginx: skip frontend build in tests

### DIFF
--- a/files/prebuild/build-frontend.sh
+++ b/files/prebuild/build-frontend.sh
@@ -1,4 +1,18 @@
 #!/bin/bash -eu
+
 cd client
-npm clean-install --no-audit --fund=false --update-notifier=false
-npm run build
+
+if [[ ${SKIP_FRONTEND_BUILD-} != "" ]]; then
+  echo "[build-frontend] Skipping frontend build."
+
+  # Create minimal fake frontend to allow tests to pass:
+  mkdir -p dist
+  echo > dist/blank.html
+  echo > dist/favicon.ico
+  echo > dist/index.html '<div id="app"></div>'
+
+  exit
+else
+  npm clean-install --no-audit --fund=false --update-notifier=false
+  npm run build
+fi

--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -8,6 +8,8 @@ RUN apt-get update \
 
 COPY ./ ./
 RUN files/prebuild/write-version.sh
+
+ARG SKIP_FRONTEND_BUILD
 RUN files/prebuild/build-frontend.sh
 
 

--- a/test/nginx.test.docker-compose.yml
+++ b/test/nginx.test.docker-compose.yml
@@ -17,6 +17,8 @@ services:
     build:
       context: ..
       dockerfile: nginx.dockerfile
+      args:
+        SKIP_FRONTEND_BUILD: true
     depends_on:
       - service
       - enketo


### PR DESCRIPTION
## Pros

This significantly decreases test turnaround time.

### Local results

```sh
./run-tests; time ./run-tests.sh
```

* with this PR: 14 seconds
* without this: 90 seconds

### CI

It looks like CI time is also decreased from ~1m45 to ~1m

## Cons

* complicates build script (`build-frontend.sh`)

#### What has been done to verify that this works as intended?

CI.

#### Why is this the best possible solution? Were any other approaches considered?

Other options might be to:

* override the `client` directory in test envs
* use a different dockerfile in tests
* override `build-frontend.sh` in test envs

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
