### PR TITLE
nginx: separate cert paths from server_name

### DIFF
--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -1,10 +1,10 @@
 server {
   listen 443 ssl;
-  server_name ${CNAME};
+  server_name ${DOMAIN};
 
-  ssl_certificate /etc/${SSL_TYPE}/live/${CNAME}/fullchain.pem;
-  ssl_certificate_key /etc/${SSL_TYPE}/live/${CNAME}/privkey.pem;
-  ssl_trusted_certificate /etc/${SSL_TYPE}/live/${CNAME}/fullchain.pem;
+  ssl_certificate /etc/${SSL_TYPE}/live/${CERT_DOMAIN}/fullchain.pem;
+  ssl_certificate_key /etc/${SSL_TYPE}/live/${CERT_DOMAIN}/privkey.pem;
+  ssl_trusted_certificate /etc/${SSL_TYPE}/live/${CERT_DOMAIN}/fullchain.pem;
 
   ssl_protocols TLSv1.2 TLSv1.3;
   ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;

--- a/files/nginx/setup-odk.sh
+++ b/files/nginx/setup-odk.sh
@@ -30,8 +30,8 @@ echo "writing fresh nginx templates..."
 # redirector.conf gets deleted if using upstream SSL so copy it back
 cp /usr/share/odk/nginx/redirector.conf /etc/nginx/conf.d/redirector.conf
 
-CNAME=$( [ "$SSL_TYPE" = "customssl" ] && echo "local" || echo "$DOMAIN") \
-envsubst '$SSL_TYPE $CNAME $SENTRY_ORG_SUBDOMAIN $SENTRY_KEY $SENTRY_PROJECT' \
+CERT_DOMAIN=$( [ "$SSL_TYPE" = "customssl" ] && echo "local" || echo "$DOMAIN") \
+envsubst '$SSL_TYPE $CERT_DOMAIN $DOMAIN $SENTRY_ORG_SUBDOMAIN $SENTRY_KEY $SENTRY_PROJECT' \
   < /usr/share/odk/nginx/odk.conf.template \
   > /etc/nginx/conf.d/odk.conf
 


### PR DESCRIPTION
Working on #809 I noticed that the location of SSL certs is based either on the domain name, or on the method of supply of SSL certs.

Cert provision approach should probably not affect the nginx "server_name" setting.

Also, the old variable name `CNAME` (short for "certificate name?") is easily confused with the DNS concept of CNAME records ("canonical names") (https://en.wikipedia.org/wiki/CNAME_record).

#### What has been done to verify that this works as intended?

Ran tests.

#### Why is this the best possible solution? Were any other approaches considered?

It may not be - there may be a subtle reason for the current use and/or naming of `CNAME`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Behaviour that may have accidentally been affected:

Servers with `SSL_TYPE` = `"customssl"` may have their nginx `server_name` changed.  This is probably a positive change - currently it has no effect, but will do once #809 is merged.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

It should not.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
