### PR TITLE
envsubst: remove explicit lists of vars

### DIFF
--- a/files/enketo/start-enketo.sh
+++ b/files/enketo/start-enketo.sh
@@ -7,7 +7,7 @@ BASE_URL=$( [ "${HTTPS_PORT}" = 443 ] && echo https://"${DOMAIN}" || echo https:
 SECRET=$(cat /etc/secrets/enketo-secret) \
 LESS_SECRET=$(cat /etc/secrets/enketo-less-secret) \
 API_KEY=$(cat /etc/secrets/enketo-api-key) \
-envsubst '$DOMAIN $BASE_URL $SECRET $LESS_SECRET $API_KEY $SUPPORT_EMAIL' \
+envsubst \
     < "$CONFIG_PATH.template" \
     > "$CONFIG_PATH"
 

--- a/files/nginx/setup-odk.sh
+++ b/files/nginx/setup-odk.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+nginx_envsubst() {
+  # Re-implementation of envsubst which is safe to call on nginx config files.
+  # This fn only substitutes variables in the form ${CAPS_AND_UNDERSCORES},
+  # allowing nginx variables like $host, $request_uri etc. through unmodified.
+  perl -pe 's/\$\{([A-Z_]*)\}/$ENV{$1}/g'
+}
+
 
 echo "writing client config..."
 if [[ $OIDC_ENABLED != 'true' ]] && [[ $OIDC_ENABLED != 'false' ]]; then
@@ -31,7 +38,7 @@ echo "writing fresh nginx templates..."
 cp /usr/share/odk/nginx/redirector.conf /etc/nginx/conf.d/redirector.conf
 
 CNAME=$( [ "$SSL_TYPE" = "customssl" ] && echo "local" || echo "$DOMAIN") \
-envsubst '$SSL_TYPE $CNAME $SENTRY_ORG_SUBDOMAIN $SENTRY_KEY $SENTRY_PROJECT' \
+nginx_envsubst \
   < /usr/share/odk/nginx/odk.conf.template \
   > /etc/nginx/conf.d/odk.conf
 

--- a/files/service/scripts/start-odk.sh
+++ b/files/service/scripts/start-odk.sh
@@ -4,7 +4,7 @@ echo "generating local service configuration.."
 
 ENKETO_API_KEY=$(cat /etc/secrets/enketo-api-key) \
 BASE_URL=$( [ "${HTTPS_PORT}" = 443 ] && echo https://"${DOMAIN}" || echo https://"${DOMAIN}":"${HTTPS_PORT}" ) \
-envsubst '$DOMAIN $BASE_URL $SYSADMIN_EMAIL $ENKETO_API_KEY $DB_HOST $DB_USER $DB_PASSWORD $DB_NAME $DB_SSL $EMAIL_FROM $EMAIL_HOST $EMAIL_PORT $EMAIL_SECURE $EMAIL_IGNORE_TLS $EMAIL_USER $EMAIL_PASSWORD $OIDC_ENABLED $OIDC_ISSUER_URL $OIDC_CLIENT_ID $OIDC_CLIENT_SECRET $SENTRY_ORG_SUBDOMAIN $SENTRY_KEY $SENTRY_PROJECT $S3_SERVER $S3_ACCESS_KEY $S3_SECRET_KEY $S3_BUCKET_NAME' \
+envsubst \
     < /usr/share/odk/config.json.template \
     > /usr/odk/config/local.json
 


### PR DESCRIPTION
For nginx config, a new approach is implemented with perl.  This is because unrestricted use of `envsubst` on nginx config files will replace nginx variables like $host, $request_uri with an empty string.

Closes #473

#### What has been done to verify that this works as intended?

CI.

#### Why is this the best possible solution? Were any other approaches considered?

Discussed on #473.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No expected effect.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
