### PR TITLE
Nginx server config: JS was not compressed

### DIFF
--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -22,7 +22,7 @@ server {
   gzip_vary on;
   gzip_min_length 1280;
   gzip_http_version 1.1;
-  gzip_types text/plain text/css application/json application/x-javascript text/xml text/csv;
+  gzip_types text/plain text/css application/json application/x-javascript application/javascript text/xml text/csv;
 
   location = /robots.txt {
     add_header Content-Type text/plain;


### PR DESCRIPTION
Closes getodk/central#819

See getodk/central#819 for details.

#### What has been done to verify that this works as intended?

- Tested on my local docker setup. (size-1500+ bytes) JS responses get compressed now.

#### Why is this the best possible solution? Were any other approaches considered?

I considered removing the `application/x-javascript` compressible type as it is severely deprecated. But who knows, perhaps some circus member proxied by nginx emits headers with that Content-Type, and in that case we'll want to compress it. It doesn't hurt to keep it around just in case.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Intentional changes: Faster and cheaper cold cache load.
Regression risk assessment: Low

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No

