### PR TITLE
test/nginx: remove misleading comment

### DIFF
--- a/test/test-nginx.js
+++ b/test/test-nginx.js
@@ -234,7 +234,6 @@ async function resetMock(port) {
 //
 // 1. do not follow redirects
 // 2. allow overriding of fetch's "forbidden" headers: https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name
-// 3. allow access to server SSL certificate
 function request(url, { body, ...options }={}) {
   if(!options.headers) options.headers = {};
   if(!options.headers.host) options.headers.host = 'odk-nginx.example.test';


### PR DESCRIPTION
This comment was merged as part of #809, but was not correct by the time the PR was merged.
