### PR TITLE
Add Central version to client-config.json

### DIFF
--- a/files/nginx/client-config.json.template
+++ b/files/nginx/client-config.json.template
@@ -1,3 +1,4 @@
 {
+  "centralVersion": "$CENTRAL_VERSION",
   "oidcEnabled": $OIDC_ENABLED
 }

--- a/files/nginx/setup-odk.sh
+++ b/files/nginx/setup-odk.sh
@@ -7,6 +7,8 @@ if [[ $OIDC_ENABLED != 'true' ]] && [[ $OIDC_ENABLED != 'false' ]]; then
   exit 1
 fi
 
+CENTRAL_VERSION=$(cat /usr/share/nginx/html/version.txt)
+export CENTRAL_VERSION
 envsubst < /usr/share/odk/nginx/client-config.json.template > /usr/share/nginx/html/client-config.json
 
 # Generate self-signed keys for the incorrect (catch-all) HTTPS listener.  This


### PR DESCRIPTION
This PR completes part of #849 and goes along with getodk/central-frontend#1099. The goal of this PR is to add the Central version from version.txt to client-config.json so that Frontend has easy access to it.

#### What has been done to verify that this works as intended?

Nothing yet. Currently, a test is failing, so I plan to patch existing tests. Once this PR is on staging, we can verify it together with getodk/central-frontend#1099.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

getodk/central-frontend#1099 is set up so that nothing breaks if `centralVersion` is missing in client-config.json.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
