### PR TITLE
Update translations in docs/ before release of v2024.3

### DIFF
--- a/docs/outdated-version.html
+++ b/docs/outdated-version.html
@@ -27,14 +27,14 @@
         "sentence2": "If you don't want to maintain Central, try {OdkCloudLink}."
       },
       "fr": {
-        "heading": "Vous utilisez une version de ODK Central considérablement obsolète",
-        "sentence1": "Mettez à jour maintenant pour protéger vos données et profiter des dernières fonctionnalités.",
-        "sentence2": "Si vous ne voulez pas maintenir Central, essayez {OdkCloudLink}."
+        "heading": "Vous utilisez une version ancienne d'ODK Central",
+        "sentence1": "Effectuez une mise à jour pour protéger vos données et profiter des fonctionnalités les plus récentes.",
+        "sentence2": "Si vous préférez ne pas être responsable des mises à jours, essayez {OdkCloudLink}."
       },
       "es": {
-        "heading": "Estás usando una versión significativamente desactualizada de ODK Central",
-        "sentence1": "Actualiza ahora para proteger tus datos y aprovechar las últimas funciones.",
-        "sentence2": "Si no quieres mantener Central, prueba {OdkCloudLink}."
+        "heading": "Está utilizando una versión significativamente obsoleta de ODK Central",
+        "sentence1": "Actualízate ahora para proteger tus datos y aprovechar las últimas funciones.",
+        "sentence2": "Si no quiere mantener Central, pruebe con {OdkCloudLink}."
       },
       "cs": {
         "heading": "Používáte výrazně zastaralou verzi ODK Central",
@@ -52,9 +52,9 @@
         "sentence2": "Jika Anda tidak ingin memelihara Central, coba {OdkCloudLink}."
       },
       "it": {
-        "heading": "Stai usando una versione di ODK Central significativamente obsoleta",
-        "sentence1": "Aggiorna ora per proteggere i tuoi dati e sfruttare le ultime funzionalità.",
-        "sentence2": "Se non vuoi mantenere Central, prova {OdkCloudLink}."
+        "heading": "Si sta utilizzando una versione significativamente obsoleta di ODK Central",
+        "sentence1": "Eseguite subito l'aggiornamento per proteggere i vostri dati e sfruttare le funzioni più recenti.",
+        "sentence2": "Se non si vuole mantenere Central, provare con {OdkCloudLink}."
       },
       "ja": {
         "heading": "ODK Central の大幅に古いバージョンを使用しています",


### PR DESCRIPTION
This PR updates the translations in outdated-version.html based on the latest translations. The new translations were automatically pulled from Transifex and can be seen in getodk/central-frontend#1108. This PR makes progress on #731.

Note that I am intentionally targeting the `master` branch.

#### What has been done to verify that this works as intended?

Only translations should have changed in this PR.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
