### PR TITLE
Update start-odk.sh memory calculation to support cgroups v2

### DIFF
--- a/files/service/scripts/start-odk.sh
+++ b/files/service/scripts/start-odk.sh
@@ -73,7 +73,8 @@ determine_worker_count() {
 }
 
 MEMTOT=$(get_memory_limit)
-export WORKER_COUNT=$(determine_worker_count "$MEMTOT")
+WORKER_COUNT=$(determine_worker_count "$MEMTOT")
+export WORKER_COUNT
 echo "using $WORKER_COUNT worker(s) based on available memory ($MEMTOT).."
 
 echo "starting server."

--- a/files/service/scripts/start-odk.sh
+++ b/files/service/scripts/start-odk.sh
@@ -30,13 +30,50 @@ fi
 echo "starting cron.."
 cron -f &
 
-MEMTOT=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
-if [ "$MEMTOT" -gt "1100000" ]
-then
-  export WORKER_COUNT=4
-else
-  export WORKER_COUNT=1
-fi
+get_cgroup_version() {
+  # The max memory calculation is different between cgroup v1 & v2
+  local cgroup_type
+  cgroup_type=$(stat -fc %T /sys/fs/cgroup/)
+  if [ "$cgroup_type" == "cgroup2fs" ]; then
+    echo "v2"
+  else
+    echo "v1"
+  fi
+}
+
+get_memory_limit() {
+  local cgroup_version
+  cgroup_version=$(get_cgroup_version)
+
+  if [ "$cgroup_version" == "v2" ]; then
+    local memtot
+    memtot=$(cat /sys/fs/cgroup/memory.max)
+    if [ "$memtot" == "max" ]; then
+      # No cgroup memory limit; fallback to system's total memory
+      memtot=$(grep MemTotal /proc/meminfo | awk '{print $2 * 1024}')
+    fi
+    # Force memtot to be an integer (not scientific notation e+09)
+    printf "%.0f\n" "$memtot"
+  else
+    # cgroup v1
+    local memtot
+    memtot=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+    # Force memtot to be an integer
+    printf "%.0f\n" "$memtot"
+  fi
+}
+
+determine_worker_count() {
+  local memtot=$1
+  if [ "$memtot" -gt 1100000 ]; then
+    echo 4
+  else
+    echo 1
+  fi
+}
+
+MEMTOT=$(get_memory_limit)
+export WORKER_COUNT=$(determine_worker_count "$MEMTOT")
 echo "using $WORKER_COUNT worker(s) based on available memory ($MEMTOT).."
 
 echo "starting server."


### PR DESCRIPTION
Closes #875 

#### Included in this PR

- The original check for cgroups v1.
- A check for cgroups v2.
  - If there are memory constraints set, then they are used.
  - If there are no memory constraints, the value will be set to `max` and we fallback to use the total memory available on the system.
- Note that it's possible to determine hard and soft memory limits via cgroups, but this is probably overkill.

#### What has been done to verify that this works as intended?

- Tested on my local Debian Bookworm setup (using WSL, so it's cgroups v1).
- Tested on a Debian Bookworm remote server, using cgroups v2.

#### Why is this the best possible solution? Were any other approaches considered?

- It seems to be a pretty common way to determine memory available inside a container.
- Containers are essentially wrappers for standard tools such as cgroups, so the total memory available in the container is determined by a cgroup.
- It doesn't require any additional tools / only uses standard Linux stuff.
- This is backwards compatible with cgroups v1 and should work for the foreseeable future (unlikely cgroups will change behaviour for a long time now).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

- Users that deployed since the commit https://github.com/hotosm/odkcentral/commit/7476a9110ed5d29279eed9e9f6a5b36f4249f646, and using cgroups v2 in their deployment infrastructure, may have an incorrectly determined number of workers!
- Likely they may be running with a single worker.
- This would increase the number of workers, depending on the memory available.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

- Probably not.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
