### PR TITLE
dev: docker-compose: expose redis locally

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -55,8 +55,12 @@ services:
   enketo_redis_main:
     profiles:
       - central
+    ports:
+      - 6379:6379
   enketo_redis_cache:
     profiles:
       - central
+    ports:
+      - 6380:6380
 volumes:
   dev_secrets:


### PR DESCRIPTION
Allowing access to enketo's redis instances locally allows this docker-compose environment to be used to work on enketo-express as well as other central services:

1. run in this repo:

	make stop && make dev && docker compose stop enketo

2. run in `enketo` repo:

	yarn workspace enketo-express grunt develop

#### What has been done to verify that this works as intended?

Tested locally.

#### Why is this the best possible solution? Were any other approaches considered?

No other approaches considered.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
