### PR TITLE
service/start: check check-migrations failure more robustly

### DIFF
--- a/files/service/scripts/start-odk.sh
+++ b/files/service/scripts/start-odk.sh
@@ -19,9 +19,7 @@ echo "running migrations.."
 node ./lib/bin/run-migrations
 
 echo "checking migration success.."
-node ./lib/bin/check-migrations
-
-if [ $? -ne 0 ]; then
+if ! node ./lib/bin/check-migrations; then
   echo "*** Error starting ODK! ***"
   echo "After attempting to automatically migrate the database, we have detected unapplied migrations, which suggests a problem with the database migration step. Please look in the console above this message for any errors and post what you find in the forum: https://forum.getodk.org/"
   exit 1

--- a/files/service/scripts/start-odk.sh
+++ b/files/service/scripts/start-odk.sh
@@ -21,7 +21,7 @@ node ./lib/bin/run-migrations
 echo "checking migration success.."
 node ./lib/bin/check-migrations
 
-if [ $? -eq 1 ]; then
+if [ $? -ne 0 ]; then
   echo "*** Error starting ODK! ***"
   echo "After attempting to automatically migrate the database, we have detected unapplied migrations, which suggests a problem with the database migration step. Please look in the console above this message for any errors and post what you find in the forum: https://forum.getodk.org/"
   exit 1


### PR DESCRIPTION
Currently, if check-migrations fails with non-1 exit code, the server will continue to start.

The existing check-migrations call and test for exit code 1 was originally introduced as a fix for #461.  The change in this PR should be more robust than the existing approach, but `set -e` and `set -o pipefail` might provide even more safety in handling failures in this script.  These latter options would also allow for complete removal of `make check-migrations` from production.

There may also be other critical scripts in this repo which would benefit from similar changes.

#### What has been done to verify that this works as intended?

Run tests, shellcheck.

#### Why is this the best possible solution? Were any other approaches considered?

As above, there are more complicated solutions which can improve and simplify this script.  However, they are also more invasive.  This change seems to be simple and an incremental improvement, so can be included more quickly than more complicated solutions which might follow.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This should not affect end users, but sysadmins deploying odk-central should find this change decreases the chances of the application starting after failed database migrations.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

I don't think so.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
