### PR TITLE
test/check-scripts: add checks to standardise whitespace

### DIFF
--- a/files/enketo/generate-secrets.sh
+++ b/files/enketo/generate-secrets.sh
@@ -11,4 +11,3 @@ fi
 if [ ! -f /etc/secrets/enketo-api-key ]; then
   LC_ALL=C tr -dc '[:alnum:]' < /dev/urandom | head -c128 > /etc/secrets/enketo-api-key
 fi
-

--- a/files/prebuild/write-version.sh
+++ b/files/prebuild/write-version.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
 
 { echo "versions:"; echo "$(git rev-parse HEAD) ($(git describe --tags))"; git submodule; } > /tmp/version.txt
-

--- a/files/service/scripts/process-backlog.sh
+++ b/files/service/scripts/process-backlog.sh
@@ -2,4 +2,3 @@
 
 cd /usr/odk
 /usr/local/bin/node lib/bin/process-backlog.js >/proc/1/fd/1 2>/proc/1/fd/2
-

--- a/files/service/scripts/purge.sh
+++ b/files/service/scripts/purge.sh
@@ -2,4 +2,3 @@
 
 cd /usr/odk
 /usr/local/bin/node lib/bin/purge.js >/proc/1/fd/1 2>/proc/1/fd/2
-

--- a/files/service/scripts/reap-sessions.sh
+++ b/files/service/scripts/reap-sessions.sh
@@ -2,4 +2,3 @@
 
 cd /usr/odk
 /usr/local/bin/node lib/bin/reap-sessions.js >/proc/1/fd/1 2>/proc/1/fd/2
-

--- a/files/service/scripts/run-analytics.sh
+++ b/files/service/scripts/run-analytics.sh
@@ -2,4 +2,3 @@
 
 cd /usr/odk
 /usr/local/bin/node lib/bin/run-analytics.js >/proc/1/fd/1 2>/proc/1/fd/2
-

--- a/files/service/scripts/start-odk.sh
+++ b/files/service/scripts/start-odk.sh
@@ -77,4 +77,3 @@ echo "using $WORKER_COUNT worker(s) based on available memory ($MEMTOT).."
 
 echo "starting server."
 exec npx pm2-runtime ./pm2.config.js
-

--- a/test/check-scripts.sh
+++ b/test/check-scripts.sh
@@ -6,6 +6,37 @@ log() { echo >&2 "[$(basename "$0")] $*"; }
 
 scriptFiles="$(cat <(git grep -El '^#!.*sh\b') <(git ls-files | grep -E '.sh$') | sort -u)"
 
+for script in $scriptFiles; do
+  log "Checking $script ..."
+
+  log "  Checking trailing whiespace on lines..."
+  if grep -E '\s+$' "$script"; then
+    log "    !!! Whitespace found at end of line !!!"
+    exit 1
+  fi
+  log "    Passed OK."
+
+  log "  Checking trailing newline in files..."
+  if [[ -n "$(tail -c 1 < "$script")" ]]; then
+    log "    !!! Missing final newline !!!"
+    exit 1
+  fi
+  if [[ -z "$(tail -c 2 < "$script")" ]]; then
+    log "    !!! Blank lines at end of file !!!"
+    exit 1
+  fi
+  log "    Passed OK."
+
+  log "  Checking for tab-based indentation..."
+  if grep -P '\t' "$script"; then
+    log "    !!! Tab(s) found."
+    log "    !!!"
+    log "    !!! Please use spaces for indentation."
+    exit 1
+  fi
+  log "    Passed OK."
+done
+
 log "Running shellcheck..."
 echo "$scriptFiles" | xargs \
     shellcheck \

--- a/test/check-scripts.sh
+++ b/test/check-scripts.sh
@@ -28,7 +28,7 @@ for script in $scriptFiles; do
   log "    Passed OK."
 
   log "  Checking for tab-based indentation..."
-  if grep -P '\t' "$script"; then
+  if grep $'\t' "$script"; then
     log "    !!! Tab(s) found."
     log "    !!!"
     log "    !!! Please use spaces for indentation."

--- a/test/check-scripts.sh
+++ b/test/check-scripts.sh
@@ -9,7 +9,7 @@ scriptFiles="$(cat <(git grep -El '^#!.*sh\b') <(git ls-files | grep -E '.sh$') 
 for script in $scriptFiles; do
   log "Checking $script ..."
 
-  log "  Checking trailing whiespace on lines..."
+  log "  Checking trailing whitespace on lines..."
   if grep -E '\s+$' "$script"; then
     log "    !!! Whitespace found at end of line !!!"
     exit 1

--- a/test/nginx/run-tests.sh
+++ b/test/nginx/run-tests.sh
@@ -23,7 +23,7 @@ wait_for_http_response() {
     printf >&2 '❌\n'
     log "!!! URL timed out: $url"
     exit 1
-  fi  
+  fi
 }
 
 log "Starting test services..."


### PR DESCRIPTION
Incidental to #891.

Whitespace changes can be introduced inadvertently due to different editor configurations.  These changes then add noise to PRs, and if committed, add noise to future diffs and the git log.

This PR adds checks for the following in `.sh` files:

* trailing spaces on lines
* trailing newlines in files
* tabs vs spaces

#### What has been done to verify that this works as intended?

Added new tests!

#### Why is this the best possible solution? Were any other approaches considered?

The status quo could be maintained.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
