### PR TITLE
ci/nginx: fix log output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,11 +29,11 @@ jobs:
     - run: cd test/nginx && ./run-tests.sh
 
     - if: always()
-      run: docker logs nginx-nginx-1 || true
+      run: cd test/nginx && docker compose -f nginx.test.docker-compose.yml logs nginx || true
     - if: always()
-      run: cd test/nginx && docker compose logs service || true
+      run: cd test/nginx && docker compose -f nginx.test.docker-compose.yml logs service || true
     - if: always()
-      run: cd test/nginx && docker compose logs enketo || true
+      run: cd test/nginx && docker compose -f nginx.test.docker-compose.yml logs enketo || true
   test-images:
     needs:
     - test-misc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,11 +29,11 @@ jobs:
     - run: cd test/nginx && ./run-tests.sh
 
     - if: always()
-      run: cd test/nginx && docker compose -f nginx.test.docker-compose.yml logs nginx
+      run: cd test/nginx && docker compose -f nginx.test.docker-compose.yml logs --no-log-prefix nginx
     - if: always()
-      run: cd test/nginx && docker compose -f nginx.test.docker-compose.yml logs service
+      run: cd test/nginx && docker compose -f nginx.test.docker-compose.yml logs --no-log-prefix service
     - if: always()
-      run: cd test/nginx && docker compose -f nginx.test.docker-compose.yml logs enketo
+      run: cd test/nginx && docker compose -f nginx.test.docker-compose.yml logs --no-log-prefix enketo
   test-images:
     needs:
     - test-misc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
     - run: cd test/nginx && ./run-tests.sh
 
     - if: always()
-      run: cd test/nginx && docker compose logs nginx || true
+      run: docker logs nginx-nginx-1 || true
     - if: always()
       run: cd test/nginx && docker compose logs service || true
     - if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,11 +29,11 @@ jobs:
     - run: cd test/nginx && ./run-tests.sh
 
     - if: always()
-      run: docker logs test-nginx-1 || true
+      run: cd test/nginx && docker compose logs nginx || true
     - if: always()
-      run: docker logs test-service-1 || true
+      run: cd test/nginx && docker compose logs service || true
     - if: always()
-      run: docker logs test-enketo-1 || true
+      run: cd test/nginx && docker compose logs enketo || true
   test-images:
     needs:
     - test-misc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,11 +29,11 @@ jobs:
     - run: cd test/nginx && ./run-tests.sh
 
     - if: always()
-      run: cd test/nginx && docker compose -f nginx.test.docker-compose.yml logs nginx || true
+      run: cd test/nginx && docker compose -f nginx.test.docker-compose.yml logs nginx
     - if: always()
-      run: cd test/nginx && docker compose -f nginx.test.docker-compose.yml logs service || true
+      run: cd test/nginx && docker compose -f nginx.test.docker-compose.yml logs service
     - if: always()
-      run: cd test/nginx && docker compose -f nginx.test.docker-compose.yml logs enketo || true
+      run: cd test/nginx && docker compose -f nginx.test.docker-compose.yml logs enketo
   test-images:
     needs:
     - test-misc


### PR DESCRIPTION
Noted while working on #830.

-----

In commit b2a9d4f933c92324013eaf85bca834c6c0919c56, the directory name containing the nginx tests was changed from `test` to `nginx`.  `docker compose` uses the parent directory name as the default name for containers, so this change broke log output which refers to specific docker logs by container name.

#### What has been done to verify that this works as intended?

Checked in CI: https://github.com/getodk/central/actions/runs/13430512089/job/37521224773

#### Why is this the best possible solution? Were any other approaches considered?

In commit b2a9d4f933c92324013eaf85bca834c6c0919c56, the directory name containing the nginx tests was changed from test to nginx. docker compose uses the parent directory name as the default name for containers, so this change broke log output which refers to specific docker logs by container name.

The approach in this commit should be more robust as:

1. it uses the docker compose service names instead of directory-derived container names, and
2. it removes `|| true`, so errors in the log command will not be suppressed.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
