### PR TITLE
Features C#906: Enable web history for vue route, catch-all to index.html

### DIFF
--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -71,6 +71,7 @@ server {
 
   location / {
     root /usr/share/nginx/html;
+    try_files $uri $uri/ /index.html;
 
     location /version.txt {
       include /usr/share/odk/nginx/common-headers.conf;


### PR DESCRIPTION
Closes getodk/central#906

#### What has been done to verify that this works as intended?

Manual verification

#### Why is this the best possible solution? Were any other approaches considered?

This is necessary to make webhistory routing mode work correctly in the frontend (Vue). Change is suggested at https://router.vuejs.org/guide/essentials/history-mode.html#nginx

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

None

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No 

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
