### PR TITLE
Block automatic npx package installation

### DIFF
--- a/files/service/scripts/start-odk.sh
+++ b/files/service/scripts/start-odk.sh
@@ -76,4 +76,4 @@ export WORKER_COUNT
 echo "using $WORKER_COUNT worker(s) based on available memory ($MEMTOT).."
 
 echo "starting server."
-exec npx pm2-runtime ./pm2.config.js
+exec npx --no pm2-runtime ./pm2.config.js

--- a/test/test-images.sh
+++ b/test/test-images.sh
@@ -57,7 +57,7 @@ check_path 2 /v1/projects '[]'
 log "  Backend started OK."
 
 log "Verifying pm2..."
-docker compose exec service npx pm2 list | tee "$tmp"
+docker compose exec service npx --no pm2 list | tee "$tmp"
 processCount="$(grep --count online "$tmp")"
 if [[ "$processCount" != 4 ]]; then
   log "!!! PM2 returned an unexpected count for online processes."


### PR DESCRIPTION
In some circumstances, `npx` will transparently install packages when asked to run a command.

From https://docs.npmjs.com/cli/v8/commands/npx#description:

> If any requested packages are not present in the local project dependencies, then they are installed to a folder in the npm cache, which is added to the PATH environment variable in the executed process. A prompt is printed (which can be suppressed by providing either `--yes` or `--no`).

Ref https://github.com/vuejs/vue-cli/commit/f36a4edfbd2bca485e64761d75490e06948abdc9

#### What has been done to verify that this works as intended?

Existing test suite.

#### Why is this the best possible solution? Were any other approaches considered?

It's safer for it to fail when dependencies are missing.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

If `npx` dependencies are not available, this should be caught by this repo's test suite.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
