### PR TITLE
Fixes/950 single submission link

### DIFF
--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -65,6 +65,11 @@ server {
     # Form fill link (non-public), or Draft
     return 301 "/f/$enketoId/new$is_args$args";
   }
+  # To read single submission cookies
+  location = /-/single/check-submitted {
+      alias /usr/share/nginx/html/blank.html;
+      default_type text/html;
+  }
 
   # For that iframe to work, we'll need another path prefix (enketo-passthrough) under which we can
   # reach Enketo — this one will not be intercepted.

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -67,8 +67,8 @@ server {
   }
   # To read single submission cookies
   location = /-/single/check-submitted {
-      alias /usr/share/nginx/html/blank.html;
-      default_type text/html;
+    alias /usr/share/nginx/html/blank.html;
+    default_type text/html;
   }
 
   # For that iframe to work, we'll need another path prefix (enketo-passthrough) under which we can

--- a/test/nginx/test-nginx.js
+++ b/test/nginx/test-nginx.js
@@ -163,6 +163,7 @@ describe('nginx config', () => {
     // then
     assert.equal(res.status, 200);
     assert.isEmpty((await res.text()).trim());
+    await assertEnketoReceivedNoRequests();
   });
 
   it('/v1/... should forward to backend', async () => {

--- a/test/nginx/test-nginx.js
+++ b/test/nginx/test-nginx.js
@@ -156,6 +156,15 @@ describe('nginx config', () => {
     });
   });
 
+  it('should serve blank page on /-/single/check-submitted', async () => {
+    // when
+    const res = await fetchHttps('/-/single/check-submitted');
+
+    // then
+    assert.equal(res.status, 200);
+    assert.isEmpty((await res.text()).trim());
+  });
+
   it('/v1/... should forward to backend', async () => {
     // when
     const res = await fetchHttps('/v1/some/central-backend/path');


### PR DESCRIPTION
Part of #950 

**Background**
For Single Submission links, Enketo’s frontend sets a cookie upon successful submission. The cookie has the format `enketoOnceId=timestamp_of_submission` and is scoped to the path /-/single.

However, since we now serve the Enketo Form from /enketo-passthrough, the cookie is no longer sent to the server, which prevents it from enforcing single submissions.

To fix this, we have added a dummy location /-/single/check-submitted in the Nginx configuration. The Central frontend loads this location in a hidden iframe and checks for the presence of the cookie with `<enketoOnceId>` key. If the cookie is found, the user is redirected to the thank-you page.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
