### PR TITLE
enketo: apply HTTP cache strategy

### DIFF
--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -97,9 +97,7 @@ server {
     add_header Pragma no-cache;
     add_header Vary "*";
 
-    if (($request_method = GET) || ($request_method = HEAD)) && (
-      $uri =~ "^/(?:-|enketo-passthrough)/js/build/"
-    )) {
+    if ($request_method = GET || $request_method = HEAD) {
       add_header Cache-Control max-age=31536000;
       unset Pragma;
       add_header Vary Accept-Encoding;

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -91,6 +91,19 @@ server {
     add_header Strict-Transport-Security "max-age=63072000" always;
     add_header X-Frame-Options "SAMEORIGIN";
     add_header X-Content-Type-Options nosniff;
+
+    # Default caching strategy: revalidate every time
+    add_header Cache-Control no-store
+    add_header Pragma no-cache
+    add_header Vary *
+
+    if ($request_method = GET) or ($request_method = HEAD) {
+      if ($uri =~ "^/(?:-|enketo-passthrough)/js/build/") {
+        add_header Cache-Control max-age=31536000
+        unset Pragma
+        add_header Vary Accept-Encoding
+      }
+    }
   }
   # End of Enketo Configuration.
 

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -7,7 +7,7 @@ server {
   return 421;
 }
 
-map "$request_method::$uri" $cache_strategy {
+map "$request_method::$uri$is_args$args" $cache_strategy {
   ~^(GET|HEAD)::/-/css/             "revalidate";
   ~^(GET|HEAD)::/-/fonts/.*?v=      "immutable";
   ~^(GET|HEAD)::/-/fonts/           "revalidate";

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -97,12 +97,12 @@ server {
     add_header Pragma no-cache;
     add_header Vary "*";
 
-    if ((($request_method = GET) or ($request_method = HEAD)) and (
-      $uri =~ "^/(?:-|enketo-passthrough)/js/build/"
-    )) {
-      add_header Cache-Control max-age=31536000;
-      unset Pragma;
-      add_header Vary Accept-Encoding;
+    if ($request_method = GET) or ($request_method = HEAD) {
+      if ($uri =~ "^/(?:-|enketo-passthrough)/js/build/") {
+        add_header Cache-Control max-age=31536000;
+        unset Pragma;
+        add_header Vary Accept-Encoding;
+      }
     }
   }
   # End of Enketo Configuration.

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -97,12 +97,12 @@ server {
     add_header Pragma no-cache;
     add_header Vary "*";
 
-    if ($request_method = GET) {
-      if ($uri =~ "^/(?:-|enketo-passthrough)/js/build/") {
-        add_header Cache-Control max-age=31536000;
-        unset Pragma;
-        add_header Vary Accept-Encoding;
-      }
+    if (($request_method = GET) or ($request_method = HEAD) and (
+      $uri =~ "^/(?:-|enketo-passthrough)/js/build/"
+    )) {
+      add_header Cache-Control max-age=31536000;
+      unset Pragma;
+      add_header Vary Accept-Encoding;
     }
   }
   # End of Enketo Configuration.

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -97,7 +97,7 @@ server {
     add_header Pragma no-cache;
     add_header Vary "*";
 
-    if ($request_method = GET) or ($request_method = HEAD) {
+    if ($request_method = GET) {
       if ($uri =~ "^/(?:-|enketo-passthrough)/js/build/") {
         add_header Cache-Control max-age=31536000;
         unset Pragma;

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -8,11 +8,11 @@ server {
 }
 
 map "$request_method::$uri" $cache_strategy {
-  ~^(GET|HEAD)::/-/js/build/chunks/ "immutable";
   ~^(GET|HEAD)::/-/css/             "revalidate";
   ~^(GET|HEAD)::/-/fonts/.*?v=      "immutable";
   ~^(GET|HEAD)::/-/fonts/           "revalidate";
   ~^(GET|HEAD)::/-/images/          "revalidate";
+  ~^(GET|HEAD)::/-/js/build/chunks/ "immutable";
   ~^(GET|HEAD)::/-/locales/         "revalidate";
   default                           "single-use";
 }

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -82,7 +82,7 @@ server {
 
     map "$request_method::$uri" $cache_strategy {
       ~^(GET|HEAD)::/js/build/ "immutable"
-      default                  "revalidate"
+      default                  "single-use"
     }
 
     if ($cache_strategy = "immutable") {
@@ -90,6 +90,11 @@ server {
       add_header Vary Accept-Encoding;
     }
     if ($cache_strategy = "revalidate") {
+      add_header Cache-Control no-cache;
+      add_header Pragma no-cache;
+      add_header Vary Accept-Encoding;
+    }
+    if ($cache_strategy = "single-use") {
       add_header Cache-Control no-store;
       add_header Pragma no-cache;
       add_header Vary "*";

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -13,6 +13,7 @@ map "$request_method::$uri" $cache_strategy {
   ~^(GET|HEAD)::/-/fonts/           "revalidate";
   ~^(GET|HEAD)::/-/images/          "revalidate";
   ~^(GET|HEAD)::/-/js/build/chunks/ "immutable";
+  ~^(GET|HEAD)::/-/js/build/        "revalidate";
   ~^(GET|HEAD)::/-/locales/         "revalidate";
   default                           "single-use";
 }

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -97,12 +97,12 @@ server {
     add_header Pragma no-cache;
     add_header Vary "*";
 
-    if ($request_method = GET) or ($request_method = HEAD) {
-      if ($uri =~ "^/(?:-|enketo-passthrough)/js/build/") {
-        add_header Cache-Control max-age=31536000;
-        unset Pragma;
-        add_header Vary Accept-Encoding;
-      }
+    if (($request_method = GET) || ($request_method = HEAD)) && (
+      $uri =~ "^/(?:-|enketo-passthrough)/js/build/"
+    )) {
+      add_header Cache-Control max-age=31536000;
+      unset Pragma;
+      add_header Vary Accept-Encoding;
     }
   }
   # End of Enketo Configuration.

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -97,7 +97,7 @@ server {
     add_header Pragma no-cache;
     add_header Vary "*";
 
-    if (($request_method = GET) or ($request_method = HEAD) and (
+    if ((($request_method = GET) or ($request_method = HEAD)) and (
       $uri =~ "^/(?:-|enketo-passthrough)/js/build/"
     )) {
       add_header Cache-Control max-age=31536000;

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -97,7 +97,7 @@ server {
     add_header Pragma no-cache;
     add_header Vary "*";
 
-    if ($request_method = GET || $request_method = HEAD) {
+    if ($request_method = GET or $request_method = HEAD) {
       add_header Cache-Control max-age=31536000;
       unset Pragma;
       add_header Vary Accept-Encoding;

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -95,8 +95,10 @@ server {
     include /usr/share/odk/nginx/enketo-common-headers.conf;
 
     map "$request_method::$uri" $cache_strategy {
-      ~^(GET|HEAD)::/js/build/ "immutable"
-      default                  "single-use"
+      ~^(GET|HEAD)::/-/js/build/      "immutable"
+      ~^(GET|HEAD)::/-/fonts/.*?v=    "immutable"
+      ~^(GET|HEAD)::/-/fonts/         "revalidate"
+      default                         "single-use"
     }
 
     if ($cache_strategy = "immutable") {

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -92,8 +92,6 @@ server {
     add_header X-Frame-Options "SAMEORIGIN";
     add_header X-Content-Type-Options nosniff;
 
-    include /usr/share/odk/nginx/enketo-common-headers.conf;
-
     map "$request_method::$uri" $cache_strategy {
       ~^(GET|HEAD)::/-/js/build/      "immutable"
       ~^(GET|HEAD)::/-/fonts/.*?v=    "immutable"

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -8,13 +8,13 @@ server {
 }
 
 map "$request_method::$uri" $cache_strategy {
-  ~^(GET|HEAD)::/-/js/build/      "immutable"
-  ~^(GET|HEAD)::/-/css/           "revalidate"
-  ~^(GET|HEAD)::/-/fonts/.*?v=    "immutable"
-  ~^(GET|HEAD)::/-/fonts/         "revalidate"
-  ~^(GET|HEAD)::/-/images/        "revalidate"
-  ~^(GET|HEAD)::/-/locales/       "revalidate"
-  default                         "single-use"
+  ~^(GET|HEAD)::/-/js/build/      "immutable";
+  ~^(GET|HEAD)::/-/css/           "revalidate";
+  ~^(GET|HEAD)::/-/fonts/.*?v=    "immutable";
+  ~^(GET|HEAD)::/-/fonts/         "revalidate";
+  ~^(GET|HEAD)::/-/images/        "revalidate";
+  ~^(GET|HEAD)::/-/locales/       "revalidate";
+  default                         "single-use";
 }
 
 server {

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -78,29 +78,21 @@ server {
     proxy_redirect off;
     proxy_set_header Host $host;
 
-    # More lax CSP for enketo-express:
-    # Google Maps API: https://developers.google.com/maps/documentation/javascript/content-security-policy
-    add_header Content-Security-Policy-Report-Only "default-src 'none'; connect-src 'self' blob: https://maps.googleapis.com/ https://maps.google.com/ https://maps.gstatic.com/mapfiles/ https://fonts.gstatic.com/ https://fonts.googleapis.com/; font-src 'self' https://fonts.gstatic.com/; frame-src 'none'; img-src data: blob: jr: 'self' https://maps.google.com/maps/ https://maps.gstatic.com/mapfiles/ https://maps.googleapis.com/maps/ https://tile.openstreetmap.org/; manifest-src 'none'; media-src blob: jr: 'self'; object-src 'none'; script-src 'unsafe-inline' 'self' https://maps.googleapis.com/maps/api/js/ https://maps.google.com/maps/ https://maps.google.com/maps-api-v3/api/js/; style-src 'unsafe-inline' 'self' https://fonts.googleapis.com/css; style-src-attr 'unsafe-inline'; report-uri /csp-report";
-    #
-    # Rules set to 'none' here would fallback to default-src if excluded.
-    # They are included here to ease interpretation of violation reports.
-    #
-    # Other security headers are identical to those in common-headers.conf;
-    # We can't just include that file here though, as it will set two Content-Security-Policy* headers
-    add_header Referrer-Policy same-origin;
-    add_header Strict-Transport-Security "max-age=63072000" always;
-    add_header X-Frame-Options "SAMEORIGIN";
-    add_header X-Content-Type-Options nosniff;
+    include /usr/share/odk/nginx/enketo-common-headers.conf;
 
-    # Default caching strategy: revalidate every time
-    add_header Cache-Control no-store;
-    add_header Pragma no-cache;
-    add_header Vary "*";
+    map "$request_method::$uri" $cache_strategy {
+      ~^(GET|HEAD)::/js/build/ "immutable"
+      default                  "revalidate"
+    }
 
-    if ($request_method = GET or $request_method = HEAD) {
+    if ($cache_strategy = "immutable") {
       add_header Cache-Control max-age=31536000;
-      unset Pragma;
       add_header Vary Accept-Encoding;
+    }
+    if ($cache_strategy = "revalidate") {
+      add_header Cache-Control no-store;
+      add_header Pragma no-cache;
+      add_header Vary "*";
     }
   }
   # End of Enketo Configuration.

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -8,13 +8,13 @@ server {
 }
 
 map "$request_method::$uri" $cache_strategy {
-  ~^(GET|HEAD)::/-/js/build/      "immutable";
-  ~^(GET|HEAD)::/-/css/           "revalidate";
-  ~^(GET|HEAD)::/-/fonts/.*?v=    "immutable";
-  ~^(GET|HEAD)::/-/fonts/         "revalidate";
-  ~^(GET|HEAD)::/-/images/        "revalidate";
-  ~^(GET|HEAD)::/-/locales/       "revalidate";
-  default                         "single-use";
+  ~^(GET|HEAD)::/-/js/build/chunks/ "immutable";
+  ~^(GET|HEAD)::/-/css/             "revalidate";
+  ~^(GET|HEAD)::/-/fonts/.*?v=      "immutable";
+  ~^(GET|HEAD)::/-/fonts/           "revalidate";
+  ~^(GET|HEAD)::/-/images/          "revalidate";
+  ~^(GET|HEAD)::/-/locales/         "revalidate";
+  default                           "single-use";
 }
 
 server {

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -78,6 +78,20 @@ server {
     proxy_redirect off;
     proxy_set_header Host $host;
 
+    # More lax CSP for enketo-express:
+    # Google Maps API: https://developers.google.com/maps/documentation/javascript/content-security-policy
+    add_header Content-Security-Policy-Report-Only "default-src 'none'; connect-src 'self' blob: https://maps.googleapis.com/ https://maps.google.com/ https://maps.gstatic.com/mapfiles/ https://fonts.gstatic.com/ https://fonts.googleapis.com/; font-src 'self' https://fonts.gstatic.com/; frame-src 'none'; img-src data: blob: jr: 'self' https://maps.google.com/maps/ https://maps.gstatic.com/mapfiles/ https://maps.googleapis.com/maps/ https://tile.openstreetmap.org/; manifest-src 'none'; media-src blob: jr: 'self'; object-src 'none'; script-src 'unsafe-inline' 'self' https://maps.googleapis.com/maps/api/js/ https://maps.google.com/maps/ https://maps.google.com/maps-api-v3/api/js/; style-src 'unsafe-inline' 'self' https://fonts.googleapis.com/css; style-src-attr 'unsafe-inline'; report-uri /csp-report";
+    #
+    # Rules set to 'none' here would fallback to default-src if excluded.
+    # They are included here to ease interpretation of violation reports.
+    #
+    # Other security headers are identical to those in common-headers.conf;
+    # We can't just include that file here though, as it will set two Content-Security-Policy* headers
+    add_header Referrer-Policy same-origin;
+    add_header Strict-Transport-Security "max-age=63072000" always;
+    add_header X-Frame-Options "SAMEORIGIN";
+    add_header X-Content-Type-Options nosniff;
+
     include /usr/share/odk/nginx/enketo-common-headers.conf;
 
     map "$request_method::$uri" $cache_strategy {

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -95,7 +95,7 @@ server {
     # Default caching strategy: revalidate every time
     add_header Cache-Control no-store
     add_header Pragma no-cache
-    add_header Vary *
+    add_header Vary "*"
 
     if ($request_method = GET) or ($request_method = HEAD) {
       if ($uri =~ "^/(?:-|enketo-passthrough)/js/build/") {

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -93,15 +93,15 @@ server {
     add_header X-Content-Type-Options nosniff;
 
     # Default caching strategy: revalidate every time
-    add_header Cache-Control no-store
-    add_header Pragma no-cache
-    add_header Vary "*"
+    add_header Cache-Control no-store;
+    add_header Pragma no-cache;
+    add_header Vary "*";
 
     if ($request_method = GET) or ($request_method = HEAD) {
       if ($uri =~ "^/(?:-|enketo-passthrough)/js/build/") {
-        add_header Cache-Control max-age=31536000
-        unset Pragma
-        add_header Vary Accept-Encoding
+        add_header Cache-Control max-age=31536000;
+        unset Pragma;
+        add_header Vary Accept-Encoding;
       }
     }
   }

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -7,6 +7,16 @@ server {
   return 421;
 }
 
+map "$request_method::$uri" $cache_strategy {
+  ~^(GET|HEAD)::/-/js/build/      "immutable"
+  ~^(GET|HEAD)::/-/css/           "revalidate"
+  ~^(GET|HEAD)::/-/fonts/.*?v=    "immutable"
+  ~^(GET|HEAD)::/-/fonts/         "revalidate"
+  ~^(GET|HEAD)::/-/images/        "revalidate"
+  ~^(GET|HEAD)::/-/locales/       "revalidate"
+  default                         "single-use"
+}
+
 server {
   listen 443 ssl;
   server_name ${DOMAIN};
@@ -91,16 +101,6 @@ server {
     add_header Strict-Transport-Security "max-age=63072000" always;
     add_header X-Frame-Options "SAMEORIGIN";
     add_header X-Content-Type-Options nosniff;
-
-    map "$request_method::$uri" $cache_strategy {
-      ~^(GET|HEAD)::/-/js/build/      "immutable"
-      ~^(GET|HEAD)::/-/css/           "revalidate"
-      ~^(GET|HEAD)::/-/fonts/.*?v=    "immutable"
-      ~^(GET|HEAD)::/-/fonts/         "revalidate"
-      ~^(GET|HEAD)::/-/images/        "revalidate"
-      ~^(GET|HEAD)::/-/locales/       "revalidate"
-      default                         "single-use"
-    }
 
     if ($cache_strategy = "immutable") {
       add_header Cache-Control max-age=31536000;

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -94,8 +94,11 @@ server {
 
     map "$request_method::$uri" $cache_strategy {
       ~^(GET|HEAD)::/-/js/build/      "immutable"
+      ~^(GET|HEAD)::/-/css/           "revalidate"
       ~^(GET|HEAD)::/-/fonts/.*?v=    "immutable"
       ~^(GET|HEAD)::/-/fonts/         "revalidate"
+      ~^(GET|HEAD)::/-/images/        "revalidate"
+      ~^(GET|HEAD)::/-/locales/       "revalidate"
       default                         "single-use"
     }
 

--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -33,7 +33,6 @@ COPY files/nginx/setup-odk.sh \
 
 COPY files/nginx/redirector.conf /usr/share/odk/nginx/
 COPY files/nginx/common-headers.conf /usr/share/odk/nginx/
-COPY files/nginx/enketo-common-headers.conf /usr/share/odk/nginx/
 
 COPY --from=intermediate client/dist/ /usr/share/nginx/html
 COPY --from=intermediate /tmp/version.txt /usr/share/nginx/html

--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -33,6 +33,7 @@ COPY files/nginx/setup-odk.sh \
 
 COPY files/nginx/redirector.conf /usr/share/odk/nginx/
 COPY files/nginx/common-headers.conf /usr/share/odk/nginx/
+COPY files/nginx/enketo-common-headers.conf /usr/share/odk/nginx/
 
 COPY --from=intermediate client/dist/ /usr/share/nginx/html
 COPY --from=intermediate /tmp/version.txt /usr/share/nginx/html

--- a/test/nginx/mock-http-server/index.js
+++ b/test/nginx/mock-http-server/index.js
@@ -16,11 +16,19 @@ app.get('/reset',       withStdLogging((req, res) => {
 
 app.get('/v1/reflect-headers', withStdLogging((req, res) => res.json(req.headers)));
 
-app.get('/{*splat}', ok('GET'));
-app.post('/{*splat}', ok('POST'));
-app.put('/{*splat}', ok('POST'));
-app.delete('/{*splat}', ok('POST'));
-// TODO add more methods as required
+const okHandler = );
+
+[
+  'delete',
+  'get',
+  'patch',
+  'post',
+  'put',
+  // TODO add more methods as required
+].forEach(method => app[method]('/{*splat}', withStdLogging((req, res) => {
+  requests.push({ method:req.method, path:req.path });
+  res.send('OK');
+});
 
 app.listen(port, () => {
   log(`Listening on port: ${port}`);
@@ -31,11 +39,4 @@ function withStdLogging(fn) {
     console.log(new Date(), req.method, req.path);
     return fn(req, res);
   };
-}
-
-function ok(method) {
-  return withStdLogging((req, res) => {
-    requests.push({ method:req.method, path:req.path });
-    res.send('OK');
-  });
 }

--- a/test/nginx/mock-http-server/index.js
+++ b/test/nginx/mock-http-server/index.js
@@ -18,6 +18,8 @@ app.get('/v1/reflect-headers', withStdLogging((req, res) => res.json(req.headers
 
 app.get('/{*splat}', ok('GET'));
 app.post('/{*splat}', ok('POST'));
+app.put('/{*splat}', ok('POST'));
+app.delete('/{*splat}', ok('POST'));
 // TODO add more methods as required
 
 app.listen(port, () => {

--- a/test/nginx/mock-http-server/index.js
+++ b/test/nginx/mock-http-server/index.js
@@ -28,7 +28,7 @@ const okHandler = );
 ].forEach(method => app[method]('/{*splat}', withStdLogging((req, res) => {
   requests.push({ method:req.method, path:req.path });
   res.send('OK');
-});
+})));
 
 app.listen(port, () => {
   log(`Listening on port: ${port}`);

--- a/test/nginx/mock-http-server/index.js
+++ b/test/nginx/mock-http-server/index.js
@@ -16,8 +16,6 @@ app.get('/reset',       withStdLogging((req, res) => {
 
 app.get('/v1/reflect-headers', withStdLogging((req, res) => res.json(req.headers)));
 
-const okHandler = );
-
 [
   'delete',
   'get',

--- a/test/nginx/mock-http-server/index.js
+++ b/test/nginx/mock-http-server/index.js
@@ -24,7 +24,7 @@ app.get('/v1/reflect-headers', withStdLogging((req, res) => res.json(req.headers
   'put',
   // TODO add more methods as required
 ].forEach(method => app[method]('/{*splat}', withStdLogging((req, res) => {
-  requests.push({ method:req.method, path:req.path });
+  requests.push({ method:req.method, path:req.originalUrl });
   res.send('OK');
 })));
 
@@ -34,7 +34,7 @@ app.listen(port, () => {
 
 function withStdLogging(fn) {
   return (req, res) => {
-    console.log(new Date(), req.method, req.path);
+    console.log(new Date(), req.method, req.originalUrl);
     return fn(req, res);
   };
 }

--- a/test/nginx/mock-http-server/index.js
+++ b/test/nginx/mock-http-server/index.js
@@ -35,7 +35,7 @@ function withStdLogging(fn) {
 
 function ok(method) {
   return withStdLogging((req, res) => {
-    requests.push({ method, path:req.path });
+    requests.push({ method:req.method, path:req.path });
     res.send('OK');
   });
 }

--- a/test/nginx/test-nginx.js
+++ b/test/nginx/test-nginx.js
@@ -264,12 +264,12 @@ describe('nginx config', () => {
       [ '/-/preview/some-id',                            'single-use' ],
       [ '/-/fonts/OpenSans-Bold-webfont.woff',           'revalidate' ],
       [ '/-/fonts/OpenSans-Regular-webfont.woff',        'revalidate' ],
-      [ '/-/fonts/fontawesome-webfont.woff?v=4.6.2',     'long' ],
+      [ '/-/fonts/fontawesome-webfont.woff?v=4.6.2',     'immutable' ],
       [ '/-/css/theme-kobo.css',                         'revalidate' ],
       [ '/-/js/build/enketo-webform.js',                 'revalidate' ],
-      [ '/-/js/build/chunks/chunk-BKEADX6Q.js',          'long' ],
-      [ '/-/js/build/chunks/chunk-Q3Q473PS.js',          'long' ],
-      [ '/-/js/build/chunks/chunk-3RPRB7E5.js',          'long' ],
+      [ '/-/js/build/chunks/chunk-BKEADX6Q.js',          'immutable' ],
+      [ '/-/js/build/chunks/chunk-Q3Q473PS.js',          'immutable' ],
+      [ '/-/js/build/chunks/chunk-3RPRB7E5.js',          'immutable' ],
       [ '/-/css/theme-kobo.print.css',                   'revalidate' ],
       [ '/-/images/icon_180x180.png',                    'revalidate' ],
       [ '/-/images/favicon.ico',                         'revalidate' ],
@@ -288,7 +288,7 @@ describe('nginx config', () => {
           // and
           await assertEnketoReceived({ method, path });
           // and
-          assertCacheStrategyApplied(expectedCacheStrategy);
+          assertCacheStrategyApplied(res, expectedCacheStrategy);
         });
       });
 
@@ -415,9 +415,9 @@ function getProtocolImplFrom(url) {
   }
 }
 
-function assertCacheStrategyApplied(expectedCacheStrategy) {
+function assertCacheStrategyApplied(res, expectedCacheStrategy) {
   switch (expectedCacheStrategy) {
-    case 'long':
+    case 'immutable':
       assert.equal(res.headers.get('Cache-Control'), 'max-age=31536000');
       assert.equal(res.headers.get('Vary'), 'Accept-Encoding');
       assert.equal(res.headers.get('Pragma'), undefined);

--- a/test/nginx/test-nginx.js
+++ b/test/nginx/test-nginx.js
@@ -284,7 +284,6 @@ describe('nginx config', () => {
 
           // then
           assert.equal(res.status, 200);
-          assert.equal(await res.text(), 'OK');
           // and
           await assertEnketoReceived({ method, path });
           // and
@@ -299,7 +298,6 @@ describe('nginx config', () => {
 
           // then
           assert.equal(res.status, 200);
-          assert.equal(await res.text(), 'OK');
           // and
           await assertEnketoReceived({ method, path });
           // and

--- a/test/nginx/test-nginx.js
+++ b/test/nginx/test-nginx.js
@@ -258,6 +258,56 @@ describe('nginx config', () => {
     socket.on('end', resolve);
     socket.on('error', reject);
   }));
+
+  describe('enketo caching', () => {
+    [
+      [ '/-/preview/some-id',                            'single-use' ],
+      [ '/-/fonts/OpenSans-Bold-webfont.woff',           'revalidate' ],
+      [ '/-/fonts/OpenSans-Regular-webfont.woff',        'revalidate' ],
+      [ '/-/fonts/fontawesome-webfont.woff?v=4.6.2',     'long' ],
+      [ '/-/css/theme-kobo.css',                         'revalidate' ],
+      [ '/-/js/build/enketo-webform.js',                 'revalidate' ],
+      [ '/-/js/build/chunks/chunk-BKEADX6Q.js',          'long' ],
+      [ '/-/js/build/chunks/chunk-Q3Q473PS.js',          'long' ],
+      [ '/-/js/build/chunks/chunk-3RPRB7E5.js',          'long' ],
+      [ '/-/css/theme-kobo.print.css',                   'revalidate' ],
+      [ '/-/images/icon_180x180.png',                    'revalidate' ],
+      [ '/-/images/favicon.ico',                         'revalidate' ],
+      [ '/-/locales/build/en/translation-combined.json', 'revalidate' ],
+      [ '/-/transform/xform/some-id',                    'single-use' ],
+      [ '/-/submission/max-size/some-id',                'single-use' ],
+    ].forEach(([ path, expectedCacheStrategy ]) => {
+      [ 'GET', 'HEAD' ].forEach(method => {
+        it(`${method} ${path} should be served with cache strategy: ${expectedCacheStrategy}`, async () => {
+          // when
+          const res = await fetchHttps(path, { method });
+
+          // then
+          assert.equal(res.status, 200);
+          assert.equal(await res.text(), 'OK');
+          // and
+          await assertEnketoReceived({ method, path });
+          // and
+          assertCacheStrategyApplied(expectedCacheStrategy);
+        });
+      });
+
+      [ 'POST', 'PUT', 'DELETE' ].forEach(method => {
+        it(`${method} ${path} should be served with cache strategy: single-use`, async () => {
+          // when
+          const res = await fetchHttps(path, { method });
+
+          // then
+          assert.equal(res.status, 200);
+          assert.equal(await res.text(), 'OK');
+          // and
+          await assertEnketoReceived({ method, path });
+          // and
+          assertCacheStrategyApplied(res, 'single-use');
+        });
+      });
+    });
+  });
 });
 
 function fetchHttp(path, options) {
@@ -362,5 +412,26 @@ function getProtocolImplFrom(url) {
     case 'http:':  return require('node:http');
     case 'https:': return require('node:https');
     default: throw new Error(`Unsupported protocol: ${protocol}`);
+  }
+}
+
+function assertCacheStrategyApplied(expectedCacheStrategy) {
+  switch (expectedCacheStrategy) {
+    case 'long':
+      assert.equal(res.headers.get('Cache-Control'), 'max-age=31536000');
+      assert.equal(res.headers.get('Vary'), 'Accept-Encoding');
+      assert.equal(res.headers.get('Pragma'), undefined);
+      break;
+    case 'revalidate':
+      assert.equal(res.headers.get('Cache-Control'), 'no-cache');
+      assert.equal(res.headers.get('Vary'), 'Accept-Encoding');
+      assert.equal(res.headers.get('Pragma'), 'no-cache');
+      break;
+    case 'single-use':
+      assert.equal(res.headers.get('Cache-Control'), 'no-store');
+      assert.equal(res.headers.get('Vary'), '*');
+      assert.equal(res.headers.get('Pragma'), 'no-cache');
+      break;
+    default: throw new Error(`Unrecognised cache strategy: ${expectedCacheStrategy}`);
   }
 }


### PR DESCRIPTION
Closes #949

#### What has been done to verify that this works as intended?

Added new tests.

#### Why is this the best possible solution? Were any other approaches considered?

Existing enketo cache headers are not always present, and sometimes means that immutable resources are not cached.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should:

* improve caching of immutable resources, giving users faster page-load times
* decrease caching of mutable items, fixing weird behaviours

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

I don't think so.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
