### PR TITLE
ci: test secrets generation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,11 +45,18 @@ jobs:
       run: cd test/nginx && docker compose -f nginx.test.docker-compose.yml logs --no-log-prefix service
     - if: always()
       run: cd test/nginx && docker compose -f nginx.test.docker-compose.yml logs --no-log-prefix enketo
+  test-secrets:
+    timeout-minutes: 2
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - run: ./test/test-secrets.sh
   test-images:
     needs:
     - test-misc
     - test-envsub
     - test-nginx
+    - test-secrets
     runs-on: ubuntu-latest # TODO matrix to run on all expected versions?
     steps:
     - uses: actions/checkout@v4

--- a/files/enketo/generate-secrets.sh
+++ b/files/enketo/generate-secrets.sh
@@ -3,13 +3,13 @@ set -o pipefail
 shopt -s inherit_errexit
 
 if [ ! -f /etc/secrets/enketo-secret ]; then
-  LC_ALL=C tr -dc '[:alnum:]' < /dev/urandom | head -c64 > /etc/secrets/enketo-secret
+  head -c1024 /dev/urandom | LC_ALL=C tr -dc '[:alnum:]' | head -c64 > /etc/secrets/enketo-secret
 fi
 
 if [ ! -f /etc/secrets/enketo-less-secret ]; then
-  LC_ALL=C tr -dc '[:alnum:]' < /dev/urandom | head -c32 > /etc/secrets/enketo-less-secret
+  head -c1024 /dev/urandom | LC_ALL=C tr -dc '[:alnum:]' | head -c32 > /etc/secrets/enketo-less-secret
 fi
 
 if [ ! -f /etc/secrets/enketo-api-key ]; then
-  LC_ALL=C tr -dc '[:alnum:]' < /dev/urandom | head -c128 > /etc/secrets/enketo-api-key
+  head -c1024 /dev/urandom | LC_ALL=C tr -dc '[:alnum:]' | head -c128 > /etc/secrets/enketo-api-key
 fi

--- a/files/enketo/generate-secrets.sh
+++ b/files/enketo/generate-secrets.sh
@@ -3,13 +3,13 @@ set -o pipefail
 shopt -s inherit_errexit
 
 if [ ! -f /etc/secrets/enketo-secret ]; then
-  head -c1024 /dev/urandom | LC_ALL=C tr -dc '[:alnum:]' | head -c64 > /etc/secrets/enketo-secret
+  head -c1024 /dev/urandom | LC_ALL=C tr -dc '[:alnum:]' | head -c64  > /etc/secrets/enketo-secret
 fi
 
 if [ ! -f /etc/secrets/enketo-less-secret ]; then
-  head -c1024 /dev/urandom | LC_ALL=C tr -dc '[:alnum:]' | head -c32 > /etc/secrets/enketo-less-secret
+  head -c512  /dev/urandom | LC_ALL=C tr -dc '[:alnum:]' | head -c32  > /etc/secrets/enketo-less-secret
 fi
 
 if [ ! -f /etc/secrets/enketo-api-key ]; then
-  head -c1024 /dev/urandom | LC_ALL=C tr -dc '[:alnum:]' | head -c128 > /etc/secrets/enketo-api-key
+  head -c2048 /dev/urandom | LC_ALL=C tr -dc '[:alnum:]' | head -c128 > /etc/secrets/enketo-api-key
 fi

--- a/test/test-secrets.sh
+++ b/test/test-secrets.sh
@@ -15,7 +15,8 @@ log "Building secrets image..."
 docker compose build --no-cache secrets
 
 log "Running container..."
-docker compose run --rm --volume "$localSecrets":/etc/secrets secrets
+#docker compose run --rm --volume "$localSecrets":/etc/secrets secrets
+docker compose run --rm secrets
 
 log "Checking secrets exist..."
 assert_size() {
@@ -38,8 +39,8 @@ assert_size() {
     exit 1
   fi
 }
-assert_size ./temp/secrets/enketo-secret       64
-assert_size ./temp/secrets/enketo-less-secret  32
-assert_size ./temp/secrets/enketo-api-key     128
+#assert_size ./temp/secrets/enketo-secret       64
+#assert_size ./temp/secrets/enketo-less-secret  32
+#assert_size ./temp/secrets/enketo-api-key     128
 
 log "Everything looks OK."

--- a/test/test-secrets.sh
+++ b/test/test-secrets.sh
@@ -4,17 +4,6 @@ shopt -s inherit_errexit
 
 log() { echo >&2 "[$(basename "$0")] $*"; }
 
-failure() {
-  log "!!! Failed !!!"
-
-  log "----- Container logs -----"
-  docker compose logs secrets
-  log "--------------------------"
-
-  log "!!! Failed !!!"
-}
-trap failure ERR
-
 localSecrets="$PWD/temp/secrets"
 if [[ -d "$localSecrets" ]]; then
   log "Cleaning local secrets directory.  This may require sudo privileges."

--- a/test/test-secrets.sh
+++ b/test/test-secrets.sh
@@ -15,8 +15,7 @@ log "Building secrets image..."
 docker compose build --no-cache secrets
 
 log "Running container..."
-#docker compose run --rm --volume "$localSecrets":/etc/secrets secrets
-docker compose run --rm secrets
+docker compose run --rm --volume "$localSecrets":/etc/secrets secrets
 
 log "Checking secrets exist..."
 assert_size() {
@@ -39,8 +38,8 @@ assert_size() {
     exit 1
   fi
 }
-#assert_size ./temp/secrets/enketo-secret       64
-#assert_size ./temp/secrets/enketo-less-secret  32
-#assert_size ./temp/secrets/enketo-api-key     128
+assert_size ./temp/secrets/enketo-secret       64
+assert_size ./temp/secrets/enketo-less-secret  32
+assert_size ./temp/secrets/enketo-api-key     128
 
 log "Everything looks OK."

--- a/test/test-secrets.sh
+++ b/test/test-secrets.sh
@@ -1,0 +1,56 @@
+#!/bin/bash -eu
+set -o pipefail
+shopt -s inherit_errexit
+
+log() { echo >&2 "[$(basename "$0")] $*"; }
+
+failure() {
+  log "!!! Failed !!!"
+
+  log "----- Container logs -----"
+  docker compose logs secrets
+  log "--------------------------"
+
+  log "!!! Failed !!!"
+}
+trap failure ERR
+
+localSecrets="$PWD/temp/secrets"
+if [[ -d "$localSecrets" ]]; then
+  log "Cleaning local secrets directory.  This may require sudo privileges."
+  sudo rm -r "$localSecrets"
+  sudo -k # revoke privileges
+fi
+
+log "Building secrets image..."
+docker compose build --no-cache secrets
+
+log "Running container..."
+docker compose run --rm --volume "$localSecrets":/etc/secrets secrets
+
+log "Checking secrets exist..."
+assert_size() {
+  local f="$1"
+  local expectedSize="$2"
+
+  if ! [[ -f "$f" ]]; then
+    log "!!! File not found: $f"
+    exit 1
+  fi
+
+  actualSize="$(stat -c "%s" "$f")"
+  if ! [[ "$actualSize" = "$expectedSize" ]]; then
+    log "!!!"
+    log "!!! Unexpected file size:"
+    log "!!!   file: $f"
+    log "!!!   expected: $expectedSize b"
+    log "!!!   actual:   $actualSize b"
+    log "!!!"
+    exit 1
+  fi
+}
+assert_size ./temp/secrets/enketo-secret       64
+assert_size ./temp/secrets/enketo-less-secret  32
+assert_size ./temp/secrets/enketo-api-key     128
+
+log "Everything looks OK."


### PR DESCRIPTION
@sadiqkhoja these tests demonstrate the issue you observed, and the code changes resolve the `PIPE` error that is thrown (on some systems).

It looks like SIGPIPE is generated when `head` completes more quickly than `tr`.

I think it's more concerning that enketo is happy to start when secrets are missing/empty.

#### What has been done to verify that this works as intended?

Add tests.

#### Why is this the best possible solution? Were any other approaches considered?

An alternative would be to ignore SIGPIPE (13 / exit code 141).  This seems risky, as there may be other reasons for pipes to fail.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

N/A?

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced

