### PR TITLE
nginx: add missing CSP headers

### DIFF
--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -89,30 +89,55 @@ server {
     proxy_redirect off;
     proxy_set_header Host $host;
 
-    # More lax CSP for enketo-express:
-    # Google Maps API: https://developers.google.com/maps/documentation/javascript/content-security-policy
-    add_header Content-Security-Policy-Report-Only "default-src 'none'; connect-src 'self' blob: https://maps.googleapis.com/ https://maps.google.com/ https://maps.gstatic.com/mapfiles/ https://fonts.gstatic.com/ https://fonts.googleapis.com/; font-src 'self' https://fonts.gstatic.com/; frame-src 'none'; img-src data: blob: jr: 'self' https://maps.google.com/maps/ https://maps.gstatic.com/mapfiles/ https://maps.googleapis.com/maps/ https://tile.openstreetmap.org/; manifest-src 'none'; media-src blob: jr: 'self'; object-src 'none'; script-src 'unsafe-inline' 'self' https://maps.googleapis.com/maps/api/js/ https://maps.google.com/maps/ https://maps.google.com/maps-api-v3/api/js/; style-src 'unsafe-inline' 'self' https://fonts.googleapis.com/css; style-src-attr 'unsafe-inline'; report-uri /csp-report";
-    #
-    # Rules set to 'none' here would fallback to default-src if excluded.
-    # They are included here to ease interpretation of violation reports.
-    #
-    # Other security headers are identical to those in common-headers.conf;
-    # We can't just include that file here though, as it will set two Content-Security-Policy* headers
-    add_header Referrer-Policy same-origin;
-    add_header Strict-Transport-Security "max-age=63072000" always;
-    add_header X-Frame-Options "SAMEORIGIN";
-    add_header X-Content-Type-Options nosniff;
-
     if ($cache_strategy = "immutable") {
+      # More lax CSP for enketo-express:
+      # Google Maps API: https://developers.google.com/maps/documentation/javascript/content-security-policy
+      add_header Content-Security-Policy-Report-Only "default-src 'none'; connect-src 'self' blob: https://maps.googleapis.com/ https://maps.google.com/ https://maps.gstatic.com/mapfiles/ https://fonts.gstatic.com/ https://fonts.googleapis.com/; font-src 'self' https://fonts.gstatic.com/; frame-src 'none'; img-src data: blob: jr: 'self' https://maps.google.com/maps/ https://maps.gstatic.com/mapfiles/ https://maps.googleapis.com/maps/ https://tile.openstreetmap.org/; manifest-src 'none'; media-src blob: jr: 'self'; object-src 'none'; script-src 'unsafe-inline' 'self' https://maps.googleapis.com/maps/api/js/ https://maps.google.com/maps/ https://maps.google.com/maps-api-v3/api/js/; style-src 'unsafe-inline' 'self' https://fonts.googleapis.com/css; style-src-attr 'unsafe-inline'; report-uri /csp-report";
+      #
+      # Rules set to 'none' here would fallback to default-src if excluded.
+      # They are included here to ease interpretation of violation reports.
+      #
+      # Other security headers are identical to those in common-headers.conf;
+      # We can't just include that file here though, as it will set two Content-Security-Policy* headers
+      add_header Referrer-Policy same-origin;
+      add_header Strict-Transport-Security "max-age=63072000" always;
+      add_header X-Frame-Options "SAMEORIGIN";
+      add_header X-Content-Type-Options nosniff;
       add_header Cache-Control max-age=31536000;
       add_header Vary Accept-Encoding;
     }
     if ($cache_strategy = "revalidate") {
+      # More lax CSP for enketo-express:
+      # Google Maps API: https://developers.google.com/maps/documentation/javascript/content-security-policy
+      add_header Content-Security-Policy-Report-Only "default-src 'none'; connect-src 'self' blob: https://maps.googleapis.com/ https://maps.google.com/ https://maps.gstatic.com/mapfiles/ https://fonts.gstatic.com/ https://fonts.googleapis.com/; font-src 'self' https://fonts.gstatic.com/; frame-src 'none'; img-src data: blob: jr: 'self' https://maps.google.com/maps/ https://maps.gstatic.com/mapfiles/ https://maps.googleapis.com/maps/ https://tile.openstreetmap.org/; manifest-src 'none'; media-src blob: jr: 'self'; object-src 'none'; script-src 'unsafe-inline' 'self' https://maps.googleapis.com/maps/api/js/ https://maps.google.com/maps/ https://maps.google.com/maps-api-v3/api/js/; style-src 'unsafe-inline' 'self' https://fonts.googleapis.com/css; style-src-attr 'unsafe-inline'; report-uri /csp-report";
+      #
+      # Rules set to 'none' here would fallback to default-src if excluded.
+      # They are included here to ease interpretation of violation reports.
+      #
+      # Other security headers are identical to those in common-headers.conf;
+      # We can't just include that file here though, as it will set two Content-Security-Policy* headers
+      add_header Referrer-Policy same-origin;
+      add_header Strict-Transport-Security "max-age=63072000" always;
+      add_header X-Frame-Options "SAMEORIGIN";
+      add_header X-Content-Type-Options nosniff;
       add_header Cache-Control no-cache;
       add_header Pragma no-cache;
       add_header Vary Accept-Encoding;
     }
     if ($cache_strategy = "single-use") {
+      # More lax CSP for enketo-express:
+      # Google Maps API: https://developers.google.com/maps/documentation/javascript/content-security-policy
+      add_header Content-Security-Policy-Report-Only "default-src 'none'; connect-src 'self' blob: https://maps.googleapis.com/ https://maps.google.com/ https://maps.gstatic.com/mapfiles/ https://fonts.gstatic.com/ https://fonts.googleapis.com/; font-src 'self' https://fonts.gstatic.com/; frame-src 'none'; img-src data: blob: jr: 'self' https://maps.google.com/maps/ https://maps.gstatic.com/mapfiles/ https://maps.googleapis.com/maps/ https://tile.openstreetmap.org/; manifest-src 'none'; media-src blob: jr: 'self'; object-src 'none'; script-src 'unsafe-inline' 'self' https://maps.googleapis.com/maps/api/js/ https://maps.google.com/maps/ https://maps.google.com/maps-api-v3/api/js/; style-src 'unsafe-inline' 'self' https://fonts.googleapis.com/css; style-src-attr 'unsafe-inline'; report-uri /csp-report";
+      #
+      # Rules set to 'none' here would fallback to default-src if excluded.
+      # They are included here to ease interpretation of violation reports.
+      #
+      # Other security headers are identical to those in common-headers.conf;
+      # We can't just include that file here though, as it will set two Content-Security-Policy* headers
+      add_header Referrer-Policy same-origin;
+      add_header Strict-Transport-Security "max-age=63072000" always;
+      add_header X-Frame-Options "SAMEORIGIN";
+      add_header X-Content-Type-Options nosniff;
       add_header Cache-Control no-store;
       add_header Pragma no-cache;
       add_header Vary "*";

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -67,6 +67,7 @@ server {
 
   server_tokens off;
 
+    add_header Content-Security-Policy-Report-Only "default-src 'none'; connect-src 'none'; font-src 'none'; frame-src 'none'; img-src 'none'; manifest-src 'none'; media-src 'none'; object-src 'none'; script-src 'none'; style-src 'none'; style-src-attr 'none'; report-uri /csp-report";
   include /usr/share/odk/nginx/common-headers.conf;
 
   client_max_body_size 100m;

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -67,7 +67,7 @@ server {
 
   server_tokens off;
 
-    add_header Content-Security-Policy-Report-Only "default-src 'none'; connect-src 'none'; font-src 'none'; frame-src 'none'; img-src 'none'; manifest-src 'none'; media-src 'none'; object-src 'none'; script-src 'none'; style-src 'none'; style-src-attr 'none'; report-uri /csp-report";
+  add_header Content-Security-Policy-Report-Only "default-src 'none'; report-uri /csp-report";
   include /usr/share/odk/nginx/common-headers.conf;
 
   client_max_body_size 100m;

--- a/test/nginx/test-nginx.js
+++ b/test/nginx/test-nginx.js
@@ -510,5 +510,5 @@ function assertCommonHeaders(res) {
   assert.equal(res.headers.get('Strict-Transport-Security'), 'max-age=63072000');
   assert.equal(res.headers.get('X-Frame-Options'), 'SAMEORIGIN');
   assert.equal(res.headers.get('X-Content-Type-Options'), 'nosniff');
-  if(csp) assert.ok(res.headers.get('Content-Security-Policy-Report-Only'));
+  assert.ok(res.headers.get('Content-Security-Policy-Report-Only'));
 }

--- a/test/nginx/test-nginx.js
+++ b/test/nginx/test-nginx.js
@@ -33,7 +33,7 @@ describe('nginx config', () => {
     // then
     assert.equal(res.status, 200);
     assert.deepEqual(await res.json(), { oidcEnabled: false });
-    assertCommonHeaders(res);
+    assertCommonHeaders({ res, csp:true });
   });
 
   it('should serve generated client-config.json (IPv6)', async () => {
@@ -43,7 +43,7 @@ describe('nginx config', () => {
     // then
     assert.equal(res.status, 200);
     assert.deepEqual(await res.json(), { oidcEnabled: false });
-    assertCommonHeaders(res);
+    assertCommonHeaders({ res, csp:true });
   });
 
   [
@@ -59,7 +59,7 @@ describe('nginx config', () => {
       // then
       assert.equal(res.status, 200);
       assert.match(await res.text(), expectedContent);
-      assertCommonHeaders(res);
+      assertCommonHeaders({ res, csp:true });
     });
   });
 
@@ -76,7 +76,7 @@ describe('nginx config', () => {
       // then
       assert.equal(res.status, 200);
       assert.equal(await res.text(), 'OK');
-      assertCommonHeaders(res);
+      assertCommonHeaders({ res, csp:true });
 
       // and
       await assertEnketoReceived(
@@ -97,7 +97,7 @@ describe('nginx config', () => {
       // then
       assert.equal(res.status, 200);
       assert.equal(await res.text(), '<div id="app"></div>\n');
-      assertCommonHeaders(res);
+      assertCommonHeaders({ res, csp:true });
 
       // and
       await assertEnketoReceivedNoRequests();
@@ -152,7 +152,7 @@ describe('nginx config', () => {
     // then
     assert.equal(res.status, 200);
     assert.equal(await res.text(), 'OK');
-    assertCommonHeaders(res);
+    assertCommonHeaders({ res, csp:true });
 
     // and
     await assertEnketoReceived(
@@ -167,7 +167,7 @@ describe('nginx config', () => {
     // then
     assert.equal(res.status, 200);
     assert.isEmpty((await res.text()).trim());
-    assertCommonHeaders(res);
+    assertCommonHeaders({ res, csp:true });
     await assertEnketoReceivedNoRequests();
   });
 
@@ -178,7 +178,7 @@ describe('nginx config', () => {
     // then
     assert.equal(res.status, 200);
     assert.equal(await res.text(), 'OK');
-    assertCommonHeaders(res);
+    assertCommonHeaders({ res, csp:false });
     // and
     await assertBackendReceived(
       { method:'GET', path:'/v1/some/central-backend/path' },
@@ -190,7 +190,7 @@ describe('nginx config', () => {
     const res = await fetchHttps('/v1/reflect-headers');
     // then
     assert.equal(res.status, 200);
-    assertCommonHeaders(res);
+    assertCommonHeaders({ res, csp:false });
 
     // when
     const body = await res.json();
@@ -208,7 +208,7 @@ describe('nginx config', () => {
     // then
     assert.equal(res.status, 200);
     // and
-    assertCommonHeaders(res);
+    assertCommonHeaders({ res, csp:false });
 
     // when
     const body = await res.json();
@@ -356,7 +356,7 @@ describe('nginx config', () => {
           // and
           assertCacheStrategyApplied(res, expectedCacheStrategy);
           // and
-          assertCommonHeaders(res);
+          assertCommonHeaders({ res, csp:true });
         });
       });
 
@@ -372,7 +372,7 @@ describe('nginx config', () => {
           // and
           assertCacheStrategyApplied(res, 'single-use');
           // and
-          assertCommonHeaders(res);
+          assertCommonHeaders({ res, csp:true });
         });
       });
     });
@@ -505,10 +505,10 @@ function assertCacheStrategyApplied(res, expectedCacheStrategy) {
   }
 }
 
-function assertCommonHeaders(res) {
+function assertCommonHeaders({ res, csp }) {
   assert.equal(res.headers.get('Referrer-Policy'), 'same-origin');
   assert.equal(res.headers.get('Strict-Transport-Security'), 'max-age=63072000');
   assert.equal(res.headers.get('X-Frame-Options'), 'SAMEORIGIN');
   assert.equal(res.headers.get('X-Content-Type-Options'), 'nosniff');
-  assert.ok(res.headers.get('Content-Security-Policy-Report-Only'));
+  if(csp) assert.ok(res.headers.get('Content-Security-Policy-Report-Only'));
 }

--- a/test/nginx/test-nginx.js
+++ b/test/nginx/test-nginx.js
@@ -33,7 +33,7 @@ describe('nginx config', () => {
     // then
     assert.equal(res.status, 200);
     assert.deepEqual(await res.json(), { oidcEnabled: false });
-    assertCommonHeaders({ res, csp:true });
+    assertCommonHeaders(res);
   });
 
   it('should serve generated client-config.json (IPv6)', async () => {
@@ -43,7 +43,7 @@ describe('nginx config', () => {
     // then
     assert.equal(res.status, 200);
     assert.deepEqual(await res.json(), { oidcEnabled: false });
-    assertCommonHeaders({ res, csp:true });
+    assertCommonHeaders(res);
   });
 
   [
@@ -59,7 +59,7 @@ describe('nginx config', () => {
       // then
       assert.equal(res.status, 200);
       assert.match(await res.text(), expectedContent);
-      assertCommonHeaders({ res, csp:true });
+      assertCommonHeaders(res);
     });
   });
 
@@ -76,7 +76,7 @@ describe('nginx config', () => {
       // then
       assert.equal(res.status, 200);
       assert.equal(await res.text(), 'OK');
-      assertCommonHeaders({ res, csp:true });
+      assertCommonHeaders(res);
 
       // and
       await assertEnketoReceived(
@@ -97,7 +97,7 @@ describe('nginx config', () => {
       // then
       assert.equal(res.status, 200);
       assert.equal(await res.text(), '<div id="app"></div>\n');
-      assertCommonHeaders({ res, csp:true });
+      assertCommonHeaders(res);
 
       // and
       await assertEnketoReceivedNoRequests();
@@ -152,7 +152,7 @@ describe('nginx config', () => {
     // then
     assert.equal(res.status, 200);
     assert.equal(await res.text(), 'OK');
-    assertCommonHeaders({ res, csp:true });
+    assertCommonHeaders(res);
 
     // and
     await assertEnketoReceived(
@@ -167,7 +167,7 @@ describe('nginx config', () => {
     // then
     assert.equal(res.status, 200);
     assert.isEmpty((await res.text()).trim());
-    assertCommonHeaders({ res, csp:true });
+    assertCommonHeaders(res);
     await assertEnketoReceivedNoRequests();
   });
 
@@ -178,7 +178,7 @@ describe('nginx config', () => {
     // then
     assert.equal(res.status, 200);
     assert.equal(await res.text(), 'OK');
-    assertCommonHeaders({ res, csp:false });
+    assertCommonHeaders(res);
     // and
     await assertBackendReceived(
       { method:'GET', path:'/v1/some/central-backend/path' },
@@ -190,7 +190,7 @@ describe('nginx config', () => {
     const res = await fetchHttps('/v1/reflect-headers');
     // then
     assert.equal(res.status, 200);
-    assertCommonHeaders({ res, csp:false });
+    assertCommonHeaders(res);
 
     // when
     const body = await res.json();
@@ -208,7 +208,7 @@ describe('nginx config', () => {
     // then
     assert.equal(res.status, 200);
     // and
-    assertCommonHeaders({ res, csp:false });
+    assertCommonHeaders(res);
 
     // when
     const body = await res.json();
@@ -356,7 +356,7 @@ describe('nginx config', () => {
           // and
           assertCacheStrategyApplied(res, expectedCacheStrategy);
           // and
-          assertCommonHeaders({ res, csp:true });
+          assertCommonHeaders(res);
         });
       });
 
@@ -372,7 +372,7 @@ describe('nginx config', () => {
           // and
           assertCacheStrategyApplied(res, 'single-use');
           // and
-          assertCommonHeaders({ res, csp:true });
+          assertCommonHeaders(res);
         });
       });
     });
@@ -505,7 +505,7 @@ function assertCacheStrategyApplied(res, expectedCacheStrategy) {
   }
 }
 
-function assertCommonHeaders({ res, csp }) {
+function assertCommonHeaders(res) {
   assert.equal(res.headers.get('Referrer-Policy'), 'same-origin');
   assert.equal(res.headers.get('Strict-Transport-Security'), 'max-age=63072000');
   assert.equal(res.headers.get('X-Frame-Options'), 'SAMEORIGIN');

--- a/test/nginx/test-nginx.js
+++ b/test/nginx/test-nginx.js
@@ -34,6 +34,7 @@ describe('nginx config', () => {
     assert.equal(res.status, 200);
     assert.deepEqual(await res.json(), { oidcEnabled: false });
     assert.equal(await res.headers.get('cache-control'), 'no-cache');
+    assertCommonHeaders(res);
   });
 
   it('should serve generated client-config.json (IPv6)', async () => {
@@ -44,6 +45,7 @@ describe('nginx config', () => {
     assert.equal(res.status, 200);
     assert.deepEqual(await res.json(), { oidcEnabled: false });
     assert.equal(await res.headers.get('cache-control'), 'no-cache');
+    assertCommonHeaders(res);
   });
 
   [
@@ -58,6 +60,7 @@ describe('nginx config', () => {
       assert.equal(res.status, 200);
       assert.match(await res.text(), expectedContent);
       assert.equal(await res.headers.get('cache-control'), 'no-cache');
+      assertCommonHeaders(res);
     });
   });
 
@@ -73,6 +76,7 @@ describe('nginx config', () => {
       // then
       assert.equal(res.status, 200);
       assert.isNull(await res.headers.get('cache-control'));
+      assertCommonHeaders(res);
     });
   });
 
@@ -89,6 +93,7 @@ describe('nginx config', () => {
       // then
       assert.equal(res.status, 200);
       assert.equal(await res.text(), 'OK');
+      assertCommonHeaders(res);
 
       // and
       await assertEnketoReceived(
@@ -109,6 +114,7 @@ describe('nginx config', () => {
       // then
       assert.equal(res.status, 200);
       assert.equal(await res.text(), '<div id="app"></div>\n');
+      assertCommonHeaders(res);
 
       // and
       await assertEnketoReceivedNoRequests();
@@ -163,6 +169,7 @@ describe('nginx config', () => {
     // then
     assert.equal(res.status, 200);
     assert.equal(await res.text(), 'OK');
+    assertCommonHeaders(res);
 
     // and
     await assertEnketoReceived(
@@ -177,6 +184,7 @@ describe('nginx config', () => {
     // then
     assert.equal(res.status, 200);
     assert.isEmpty((await res.text()).trim());
+    assertCommonHeaders(res);
     await assertEnketoReceivedNoRequests();
   });
 
@@ -187,6 +195,7 @@ describe('nginx config', () => {
     // then
     assert.equal(res.status, 200);
     assert.equal(await res.text(), 'OK');
+    assertCommonHeaders(res);
     // and
     await assertBackendReceived(
       { method:'GET', path:'/v1/some/central-backend/path' },
@@ -198,6 +207,7 @@ describe('nginx config', () => {
     const res = await fetchHttps('/v1/reflect-headers');
     // then
     assert.equal(res.status, 200);
+    assertCommonHeaders(res);
 
     // when
     const body = await res.json();
@@ -214,6 +224,8 @@ describe('nginx config', () => {
     });
     // then
     assert.equal(res.status, 200);
+    // and
+    assertCommonHeaders(res);
 
     // when
     const body = await res.json();
@@ -302,6 +314,8 @@ describe('nginx config', () => {
           await assertEnketoReceived({ method, path });
           // and
           assertCacheStrategyApplied(res, expectedCacheStrategy);
+          // and
+          assertCommonHeaders(res);
         });
       });
 
@@ -316,6 +330,8 @@ describe('nginx config', () => {
           await assertEnketoReceived({ method, path });
           // and
           assertCacheStrategyApplied(res, 'single-use');
+          // and
+          assertCommonHeaders(res);
         });
       });
     });
@@ -446,4 +462,13 @@ function assertCacheStrategyApplied(res, expectedCacheStrategy) {
       break;
     default: throw new Error(`Unrecognised cache strategy: ${expectedCacheStrategy}`);
   }
+}
+
+function assertCommonHeaders(res) {
+  assert.equal(res.headers.get('Referrer-Policy', 'same-origin'));
+  assert.equal(res.headers.get('Strict-Transport-Security', '"max-age=63072000" always'));
+  assert.equal(res.headers.get('X-Frame-Options', '"SAMEORIGIN"'));
+  assert.equal(res.headers.get('X-Content-Type-Options', 'nosniff'));
+  assert.equal(res.headers.get('X-Content-Type-Options', 'nosniff'));
+  assert.ok(res.headers.get('Content-Security-Policy-Report-Only'));
 }

--- a/test/nginx/test-nginx.js
+++ b/test/nginx/test-nginx.js
@@ -465,10 +465,9 @@ function assertCacheStrategyApplied(res, expectedCacheStrategy) {
 }
 
 function assertCommonHeaders(res) {
-  assert.equal(res.headers.get('Referrer-Policy', 'same-origin'));
-  assert.equal(res.headers.get('Strict-Transport-Security', '"max-age=63072000" always'));
-  assert.equal(res.headers.get('X-Frame-Options', '"SAMEORIGIN"'));
-  assert.equal(res.headers.get('X-Content-Type-Options', 'nosniff'));
-  assert.equal(res.headers.get('X-Content-Type-Options', 'nosniff'));
+  assert.equal(res.headers.get('Referrer-Policy'), 'same-origin');
+  assert.equal(res.headers.get('Strict-Transport-Security'), '"max-age=63072000" always');
+  assert.equal(res.headers.get('X-Frame-Options'), '"SAMEORIGIN"');
+  assert.equal(res.headers.get('X-Content-Type-Options'), 'nosniff');
   assert.ok(res.headers.get('Content-Security-Policy-Report-Only'));
 }

--- a/test/nginx/test-nginx.js
+++ b/test/nginx/test-nginx.js
@@ -466,7 +466,7 @@ function assertCacheStrategyApplied(res, expectedCacheStrategy) {
 
 function assertCommonHeaders(res) {
   assert.equal(res.headers.get('Referrer-Policy'), 'same-origin');
-  assert.equal(res.headers.get('Strict-Transport-Security'), '"max-age=63072000" always');
+  assert.equal(res.headers.get('Strict-Transport-Security'), '"max-age=63072000"');
   assert.equal(res.headers.get('X-Frame-Options'), '"SAMEORIGIN"');
   assert.equal(res.headers.get('X-Content-Type-Options'), 'nosniff');
   assert.ok(res.headers.get('Content-Security-Policy-Report-Only'));

--- a/test/nginx/test-nginx.js
+++ b/test/nginx/test-nginx.js
@@ -466,8 +466,8 @@ function assertCacheStrategyApplied(res, expectedCacheStrategy) {
 
 function assertCommonHeaders(res) {
   assert.equal(res.headers.get('Referrer-Policy'), 'same-origin');
-  assert.equal(res.headers.get('Strict-Transport-Security'), '"max-age=63072000"');
-  assert.equal(res.headers.get('X-Frame-Options'), '"SAMEORIGIN"');
+  assert.equal(res.headers.get('Strict-Transport-Security'), 'max-age=63072000');
+  assert.equal(res.headers.get('X-Frame-Options'), 'SAMEORIGIN');
   assert.equal(res.headers.get('X-Content-Type-Options'), 'nosniff');
   assert.ok(res.headers.get('Content-Security-Policy-Report-Only'));
 }


### PR DESCRIPTION
Noted while working on #984 that:

1. these headers were not tested, and
2. cache header changes affected the application of content-security-policy headers

This adds a default more restrictive CSP for routes which do not have other headers set.

#### What has been done to verify that this works as intended?

New tests for all expected security headers for 200 responses in `test-nginx.js`.

#### Why is this the best possible solution? Were any other approaches considered?

It might also be an option to omit CSP from e.g. API requests.  However, there are various obscure scenarios where a policy can still be helpful, so including a short, very restrictive policy by default seems fail-safe.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This change should not cause regressions, as although the CSP has changed in some cases, it is still set to report-only.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
