### PR TITLE
enketo: fail startup if secrets missing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,12 @@ jobs:
         fetch-tags: true
         submodules: recursive
     - run: cd test/envsub && ./run-tests.sh
+  test-enketo:
+    timeout-minutes: 2
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - run: ./test/test-enketo.sh
   test-nginx:
     timeout-minutes: 10
     runs-on: ubuntu-latest
@@ -49,6 +55,7 @@ jobs:
     needs:
     - test-misc
     - test-envsub
+    - test-enketo
     - test-nginx
     runs-on: ubuntu-latest # TODO matrix to run on all expected versions?
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@
 
 /files/dkim/*
 
-/temp
+/temp/

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 /files/mail/rsa.public
 
 /files/dkim/*
+
+/temp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,9 +124,8 @@ services:
     build:
       context: .
       dockerfile: enketo.dockerfile
-    restart: always
+    restart: no
     depends_on:
-      - secrets
       - enketo_redis_main
       - enketo_redis_cache
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,8 +124,9 @@ services:
     build:
       context: .
       dockerfile: enketo.dockerfile
-    restart: no
+    restart: always
     depends_on:
+      - secrets
       - enketo_redis_main
       - enketo_redis_cache
     environment:

--- a/files/enketo/start-enketo.sh
+++ b/files/enketo/start-enketo.sh
@@ -4,6 +4,31 @@ shopt -s inherit_errexit
 
 log() { echo >&2 "[$(basename "$0")] $*"; }
 
+log "Checking secrets exist..."
+assert_size() {
+  local f="$1"
+  local expectedSize="$2"
+
+  if ! [[ -f "$f" ]]; then
+    log "!!! File not found: $f"
+    exit 1
+  fi
+
+  actualSize="$(stat -c "%s" "$f")"
+  if ! [[ "$actualSize" = "$expectedSize" ]]; then
+    log "!!!"
+    log "!!! Unexpected file size:"
+    log "!!!   file: $f"
+    log "!!!   expected: $expectedSize b"
+    log "!!!   actual:   $actualSize b"
+    log "!!!"
+    exit 1
+  fi
+}
+assert_size /etc/secrets/enketo-secret       64
+assert_size /etc/secrets/enketo-less-secret  32
+assert_size /etc/secrets/enketo-api-key     128
+
 CONFIG_PATH=${ENKETO_SRC_DIR}/config/config.json
 log "Generating enketo configuration..."
 

--- a/files/enketo/start-enketo.sh
+++ b/files/enketo/start-enketo.sh
@@ -4,31 +4,6 @@ shopt -s inherit_errexit
 
 log() { echo >&2 "[$(basename "$0")] $*"; }
 
-log "Checking secrets exist..."
-assert_size() {
-  local f="$1"
-  local expectedSize="$2"
-
-  if ! [[ -f "$f" ]]; then
-    log "!!! File not found: $f"
-    exit 1
-  fi
-
-  actualSize="$(stat -c "%s" "$f")"
-  if ! [[ "$actualSize" = "$expectedSize" ]]; then
-    log "!!!"
-    log "!!! Unexpected file size:"
-    log "!!!   file: $f"
-    log "!!!   expected: $expectedSize b"
-    log "!!!   actual:   $actualSize b"
-    log "!!!"
-    exit 1
-  fi
-}
-assert_size /etc/secrets/enketo-secret       64
-assert_size /etc/secrets/enketo-less-secret  32
-assert_size /etc/secrets/enketo-api-key     128
-
 CONFIG_PATH=${ENKETO_SRC_DIR}/config/config.json
 log "Generating enketo configuration..."
 

--- a/test/enketo.test.docker-compose.yml
+++ b/test/enketo.test.docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  enketo:
+    build:
+      context: ..
+      dockerfile: enketo.dockerfile
+    restart: no

--- a/test/test-enketo.sh
+++ b/test/test-enketo.sh
@@ -14,7 +14,9 @@ exitCode="$?"
 set -e
 
 if [[ "$exitCode" = 124 ]]; then
+  log "!!!"
   log "!!! Enketo startup did not fail, despite invalid config."
+  log "!!!"
   exit 1
 elif [[ "$exitCode" = 1 ]]; then
   log "Enketo exited correctly."

--- a/test/test-enketo.sh
+++ b/test/test-enketo.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -eu
+set -o pipefail
+shopt -s inherit_errexit
+
+log() { echo >&2 "[$(basename "$0")] $*"; }
+
+log "Building docker image..."
+docker compose build --no-cache enketo
+#docker compose build enketo
+
+log "Starting container..."
+set +e
+timeout --foreground 10 docker compose run --rm --no-deps enketo
+exitCode="$?"
+set -e
+
+if [[ "$exitCode" = 124 ]]; then
+  log "!!! Enketo startup did not fail, despite invalid config."
+  exit 1
+else
+  log "Enketo exited _correctly_ with code: $exitCode"
+  # TODO assert specific exit code?
+fi
+
+log "Everything looks OK."

--- a/test/test-enketo.sh
+++ b/test/test-enketo.sh
@@ -5,8 +5,7 @@ shopt -s inherit_errexit
 log() { echo >&2 "[$(basename "$0")] $*"; }
 
 log "Building docker image..."
-docker compose build --no-cache enketo
-#docker compose build enketo
+docker compose --file ./test/enketo.test.docker-compose.yml build --no-cache enketo
 
 log "Starting container..."
 set +e
@@ -17,9 +16,11 @@ set -e
 if [[ "$exitCode" = 124 ]]; then
   log "!!! Enketo startup did not fail, despite invalid config."
   exit 1
+elif [[ "$exitCode" = 1 ]]; then
+  log "Enketo exited correctly."
 else
-  log "Enketo exited _correctly_ with code: $exitCode"
-  # TODO assert specific exit code?
+  log "Enketo exited with unexpected status: $exitCode"
+  exit 1
 fi
 
 log "Everything looks OK."


### PR DESCRIPTION
Relates to https://github.com/getodk/central/pull/982

#### What has been done to verify that this works as intended?

- [x] added test for failure condition
- [x] existing tests
- [ ] `test-images.sh` should also be checking that the enketo service is starting ok

#### Why is this the best possible solution? Were any other approaches considered?

It's quite a simple approach.  An obvious alternative would be to move the check scripts to a `healthcheck` in the secrets service, and add `service_healthy` to enketo's `depends_on` config (see https://docs.docker.com/compose/how-tos/startup-order/).

That seems more complex, and unclear if that will work given that the `secrets` service shuts down after it has generated the secrets.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

There's a danger that the approach in this PR introduces a race condition - perhaps the file/size checks should be repeated if they fail.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
