### PR TITLE
test-nginx: use proper express middleware

### DIFF
--- a/test/nginx/mock-http-server/index.js
+++ b/test/nginx/mock-http-server/index.js
@@ -7,14 +7,19 @@ const requests = [];
 
 const app = express();
 
-app.get('/health',      withStdLogging((req, res) => res.send('OK')));
-app.get('/request-log', withStdLogging((req, res) => res.json(requests)));
-app.get('/reset',       withStdLogging((req, res) => {
+app.use((req, res, next) => {
+  console.log(new Date(), req.method, req.originalUrl);
+  next();
+});
+
+app.get('/health',      (req, res) => res.send('OK'));
+app.get('/request-log', (req, res) => res.json(requests));
+app.get('/reset',       (req, res) => {
   requests.length = 0;
   res.json('OK');
-}));
+});
 
-app.get('/v1/reflect-headers', withStdLogging((req, res) => res.json(req.headers)));
+app.get('/v1/reflect-headers', (req, res) => res.json(req.headers));
 
 [
   'delete',
@@ -23,7 +28,7 @@ app.get('/v1/reflect-headers', withStdLogging((req, res) => res.json(req.headers
   'post',
   'put',
   // TODO add more methods as required
-].forEach(method => app[method]('/{*splat}', withStdLogging((req, res) => {
+].forEach(method => app[method]('/{*splat}', (req, res) => {
   requests.push({ method:req.method, path:req.originalUrl });
   res.send('OK');
 })));
@@ -31,10 +36,3 @@ app.get('/v1/reflect-headers', withStdLogging((req, res) => res.json(req.headers
 app.listen(port, () => {
   log(`Listening on port: ${port}`);
 });
-
-function withStdLogging(fn) {
-  return (req, res) => {
-    console.log(new Date(), req.method, req.originalUrl);
-    return fn(req, res);
-  };
-}

--- a/test/nginx/mock-http-server/index.js
+++ b/test/nginx/mock-http-server/index.js
@@ -31,7 +31,7 @@ app.get('/v1/reflect-headers', (req, res) => res.json(req.headers));
 ].forEach(method => app[method]('/{*splat}', (req, res) => {
   requests.push({ method:req.method, path:req.originalUrl });
   res.send('OK');
-})));
+}));
 
 app.listen(port, () => {
   log(`Listening on port: ${port}`);


### PR DESCRIPTION
The `withStdLogging()` function was behaving as express middleware, while introducing a less idiomatic syntax.  This commit reverts access logs to operate as normal express middleware.

Noted while working on #984

#### What has been done to verify that this works as intended?

- [x] checked log outputs at https://github.com/getodk/central/actions/runs/14701262069/job/41251079066?pr=990

#### Why is this the best possible solution? Were any other approaches considered?

Could have left as-is, but the current syntax hinders adding new tests consistently.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
