### PR TITLE
Fixes offline enketo

### DIFF
--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -101,10 +101,6 @@ server {
     # preview link
     return 301 "/f/$enketoId/preview$is_args$args";
   }
-  location ~ "^/-/x/(?<enketoId>[a-zA-Z0-9]+)$" {
-    # Offline new Submissions - can be public if it has st query parameter
-    return 301 "/f/$enketoId/offline$is_args$args";
-  }
   location ~ "^/-/(?!thanks$)(?<enketoId>[a-zA-Z0-9]+)$" {
     # Form fill link (non-public), or Draft
     return 301 "/f/$enketoId/new$is_args$args";

--- a/test/nginx/test-nginx.js
+++ b/test/nginx/test-nginx.js
@@ -199,10 +199,6 @@ describe('nginx config', () => {
       request: `/-/preview/${enketoId}`,
       expected: `f/${enketoId}/preview` },
 
-    { description: 'offline submission',
-      request: `/-/x/${enketoId}`,
-      expected: `f/${enketoId}/offline` },
-
     { description: 'new or draft submission',
       request: `/-/${enketoId}`,
       expected: `f/${enketoId}/new` },


### PR DESCRIPTION
Corresponding change of https://github.com/getodk/central-frontend/pull/1201

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
