### PR TITLE
nginx/enketo: strip upstream cache headers

### DIFF
--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -118,6 +118,8 @@ server {
     proxy_pass http://enketo:8005;
     proxy_redirect off;
     proxy_set_header Host $host;
+    proxy_hide_header Vary;
+    proxy_hide_header Cache-Control;
 
     # More lax CSP for enketo-express:
     # Google Maps API: https://developers.google.com/maps/documentation/javascript/content-security-policy

--- a/test/nginx/mock-http-server/index.js
+++ b/test/nginx/mock-http-server/index.js
@@ -12,6 +12,13 @@ app.use((req, res, next) => {
   next();
 });
 
+// Enketo express returns response with Vary and Cache-Control headers
+app.use('/-/', (req, res, next) => {
+  res.set('Vary', 'Accept-Encoding');
+  res.set('Cache-Control', 'public, max-age=0');
+  next();
+});
+
 app.get('/health',      (req, res) => res.send('OK'));
 app.get('/request-log', (req, res) => res.json(requests));
 app.get('/reset',       (req, res) => {


### PR DESCRIPTION
Without this PR: nginx returns multiple Vary and Cache-Control headers:

```
curl -I https://staging.getodk.cloud/-/x/css/theme-kobo.css
```

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
