### PR TITLE
Part3: Use revalidate strategy of Offline Enketo html page

### DIFF
--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -32,6 +32,7 @@ map "$request_method::$uri$is_args$args" $cache_strategy {
   ~^(GET|HEAD)::/-(/x)?/js/build/chunks/ "immutable";
   ~^(GET|HEAD)::/-(/x)?/js/build/        "revalidate";
   ~^(GET|HEAD)::/-(/x)?/locales/         "revalidate";
+  ~^(GET|HEAD)::/-/x/[a-zA-Z0-9]+$       "revalidate";
 
   default "single-use";
 }

--- a/test/nginx/test-nginx.js
+++ b/test/nginx/test-nginx.js
@@ -437,6 +437,7 @@ describe('nginx config', () => {
       [ '/-/x/images/icon_180x180.png',                    'revalidate' ],
       [ '/-/x/images/favicon.ico',                         'revalidate' ],
       [ '/-/x/locales/build/en/translation-combined.json', 'revalidate' ],
+      [ '/-/x/0n1W082ZWvx1O7XDsmHNqfwSrIjeeIH',            'revalidate' ],
     ].forEach(([ path, expectedCacheStrategy ]) => {
       [ 'GET', 'HEAD' ].forEach(method => {
         it(`${method} ${path} should be served with cache strategy: ${expectedCacheStrategy}`, async () => {


### PR DESCRIPTION
Closes #998

I forgot to add this change in https://github.com/getodk/central/pull/1005

Enketo Offline mode manually caches html page as well, and if we return `Vary: *` then browser doesn't allow it cache it and throws:

```
offline-app-worker.js:123 Uncaught (in promise) TypeError: Failed to execute 'put' on 'Cache': Vary header contains *
    at offline-app-worker.js:123:31
```

#### Before submitting this PR, please make sure you have:

- [ ] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
