### PR TITLE
test-images: increase timeout

### DIFF
--- a/test/test-images.sh
+++ b/test/test-images.sh
@@ -50,7 +50,7 @@ log "Starting containers..."
 docker compose up --detach
 
 log "Verifying frontend..."
-check_path 60 / 'ODK Central'
+check_path 180 / 'ODK Central'
 log "  Frontend started OK."
 
 log "Verifying backend..."


### PR DESCRIPTION
As observed in #996, the nginx container startup can take varying amounts of time due to Diffie Helman key generation.

With the current timeout of 60 seconds, this can cause occasional CI failures, e.g. https://github.com/getodk/central/actions/runs/14791863150/job/41530577306?pr=992:

These failures will have a final `nginx` log entry like:

	Generating DH parameters, 2048 bit long safe prime

#### What has been done to verify that this works as intended?

CI.

#### Why is this the best possible solution? Were any other approaches considered?

As in #996, DH key generation could be skipped.  It's good to test it somewhere though, and the `test-images` job is expected to be slower and more thorough than other CI test jobs.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No change.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [ ] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
