### PR TITLE
ci/test-images: add timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,7 @@ jobs:
     - uses: actions/checkout@v4
     - run: ./test/test-secrets.sh
   test-images:
+    timeout-minutes: 10
     needs:
     - test-misc
     - test-envsub


### PR DESCRIPTION
Normal time for this job to complete is 3-4 minutes.  Setting an overall timeout of 10 minutes should allow for occasional slowdown of execution, while preventing runaway build processes from going on forever.

Related: https://github.com/getodk/central/pull/1016

#### What has been done to verify that this works as intended?

CI.

#### Why is this the best possible solution? Were any other approaches considered?

Simple, and consistent with other CI jobs.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [ ] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
