### PR TITLE
Revert "nginx: simplify enketo passthrough rewrites"

### DIFF
--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -110,11 +110,8 @@ server {
 
   # For that iframe to work, we'll need another path prefix (enketo-passthrough) under which we can
   # reach Enketo — this one will not be intercepted.
-  location ~ ^/enketo-passthrough(/.*)?$ {
-    rewrite ^/enketo-passthrough(/.*)?$ /-$1 last;
-  }
-
-  location ~ ^/-(/.*)?$ {
+  location ~ ^/(?:-|enketo-passthrough)(?:/|$) {
+    rewrite ^/enketo-passthrough(/.*)?$ /-$1 break;
     proxy_pass http://enketo:8005;
     proxy_redirect off;
     proxy_set_header Host $host;

--- a/test/nginx/test-nginx.js
+++ b/test/nginx/test-nginx.js
@@ -153,6 +153,7 @@ describe('nginx config', () => {
     { request: '/-',                                   expected: '/-' },
     { request: '/enketo-passthrough/some/enketo/path', expected: '/-/some/enketo/path' },
     { request: '/enketo-passthrough',                  expected: '/-' },
+    { request: '/enketo-passthrough/enketoid',         expected: '/-/enketoid' },
   ].forEach(t => {
     it(`should forward to enketo; ${t.request}`, async () => {
       // when


### PR DESCRIPTION
Reverts getodk/central#992

After `rewrite ^/enketo-passthrough(/.*)?$ /-$1 ....`, we don't want enketo redirection rules (`/-/...`  -> `/f/...` ) to execute again