### PR TITLE
do not forward /connection to central-frontend

### DIFF
--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -99,7 +99,7 @@ server {
     # preview link
     return 301 "/f/$enketoId/preview$is_args$args";
   }
-  location ~ "^/-/(?!thanks$)(?<enketoId>[a-zA-Z0-9]+)$" {
+  location ~ "^/-/(?!thanks$)(?!connection$)(?<enketoId>[a-zA-Z0-9]+)$" {
     # Form fill link (non-public), or Draft
     return 301 "/f/$enketoId/new$is_args$args";
   }

--- a/test/nginx/test-nginx.js
+++ b/test/nginx/test-nginx.js
@@ -227,19 +227,24 @@ describe('nginx config', () => {
     });
   });
 
-  it('should not redirect thanks page to central-frontend', async () => {
-    // when
-    const res = await fetchHttps('/-/thanks');
+  [
+    '/-/thanks',
+    '/-/connection',
+  ].forEach(request => {
+    it(`should not redirect ${request} to central-frontend`, async () => {
+      // when
+      const res = await fetchHttps(request);
 
-    // then
-    assert.equal(res.status, 200);
-    assert.equal(await res.text(), 'OK');
-    assertSecurityHeaders(res, { csp:'enketo' });
+      // then
+      assert.equal(res.status, 200);
+      assert.equal(await res.text(), 'OK');
+      assertSecurityHeaders(res, { csp:'enketo' });
 
-    // and
-    await assertEnketoReceived(
-      { method:'GET', path: '/-/thanks' },
-    );
+      // // and
+      await assertEnketoReceived(
+        { method:'GET', path: request },
+      );
+    });
   });
 
   it('should serve blank page on /-/single/check-submitted', async () => {


### PR DESCRIPTION
Enketo sends frequent `/-/connection` request to check connectivity, currently nginx is returning 301 therefore Enketo can't send queued submissions even when connection is back.

I have test this change in staging env and verified the functionality in Chrome and Firefox.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
