### PR TITLE
Fixes/more enketo exceptions

### DIFF
--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -99,7 +99,10 @@ server {
     # preview link
     return 301 "/f/$enketoId/preview$is_args$args";
   }
-  location ~ "^/-/(?!thanks$)(?!connection$)(?<enketoId>[a-zA-Z0-9]+)$" {
+  # The negative look ahead patterns in the following regex are for the Enketo endpoints which are
+  # similar to the new submission endpoint i.e. /-/:enketoId but these are not enketoId, therefore
+  # we don't want them to be redirected to central-frontend
+  location ~ "^/-/(?!thanks$|connection$|login$|logout$|api$|preview$)(?<enketoId>[a-zA-Z0-9]+)$" {
     # Form fill link (non-public), or Draft
     return 301 "/f/$enketoId/new$is_args$args";
   }

--- a/test/nginx/test-nginx.js
+++ b/test/nginx/test-nginx.js
@@ -213,6 +213,18 @@ describe('nginx config', () => {
     { description: 'new or draft submission',
       request: `/-/${enketoId}`,
       expected: `f/${enketoId}/new` },
+
+    { description: 'new submission - enketoId starts with thanks',
+      request: `/-/thanksokay`,
+      expected: `f/thanksokay/new` },
+
+    { description: 'new submission - enketoId ends with thanks',
+        request: `/-/okaythanks`,
+        expected: `f/okaythanks/new` },
+
+    { description: 'new submission - enketoId contains thanks',
+      request: `/-/okaythanksokay`,
+      expected: `f/okaythanksokay/new` },
   ];
   enketoRedirectTestData.forEach(t => {
     it('should redirect old enketo links to central-frontend; ' + t.description, async () => {
@@ -230,6 +242,10 @@ describe('nginx config', () => {
   [
     '/-/thanks',
     '/-/connection',
+    '/-/login',
+    '/-/logout',
+    '/-/api',
+    '/-/preview',
   ].forEach(request => {
     it(`should not redirect ${request} to central-frontend`, async () => {
       // when


### PR DESCRIPTION
Went through Enketo source code to see what are the other endpoints that matches `/-/[a-zA-Z0-9]+` pattern. We don't want them to be redirected to central-frontend.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
