### PR TITLE
Pass through backend cache headers

### DIFF
--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -14,6 +14,9 @@ map "$request_method::$uri$is_args$args" $cache_strategy {
   ~^(GET|HEAD)::/robots.txt$         "revalidate";
   ~^(GET|HEAD)::/version.txt$        "revalidate";
 
+  # central-backend
+  ~^(GET|HEAD)::/v1/                 "passthrough";
+
   # central-frontend - unversioned
   ~^(GET|HEAD)::/$             "revalidate";
   ~^(GET|HEAD)::/index.html$   "revalidate";
@@ -41,16 +44,19 @@ map "$request_method::$uri$is_args$args" $cache_strategy {
 map $cache_strategy $cache_header_cache_control {
   "immutable"  "max-age=31536000";
   "revalidate" "no-cache";
+  "passthrough"  "";
   default      "no-store";
 }
 map $cache_strategy $cache_header_pragma {
   "immutable"  "";
   "revalidate" "no-cache";
+  "passthrough"  "";
   default      "no-cache";
 }
 map $cache_strategy $cache_header_vary {
   "immutable"  "Accept-Encoding";
   "revalidate" "Accept-Encoding";
+  "passthrough"  "";
   default      "*";
 }
 

--- a/test/nginx/test-nginx.js
+++ b/test/nginx/test-nginx.js
@@ -378,10 +378,6 @@ describe('nginx config', () => {
       [ '/robots.txt',               'revalidate' ],
       [ '/version.txt',              'revalidate' ],
 
-      // central-backend
-      [ '/v1/foo',                   'passthrough' ],
-      [ '/v1/foo/bar/baz',           'passthrough' ],
-
       // central-frontend - unversioned
       [ '/',                         'revalidate' ],
       [ '/index.html',               'revalidate' ],
@@ -433,6 +429,25 @@ describe('nginx config', () => {
       });
     });
   });
+
+  describe('backend caching', () => {
+    [
+      [ '/v1/foo',                   'passthrough' ],
+      [ '/v1/foo/bar/baz',           'passthrough' ]
+    ].forEach(([ path, expectedCacheStrategy ]) => {
+      [ 'GET', 'HEAD' ].forEach(method => {
+        it(`${method} ${path} should be served with cache strategy: ${expectedCacheStrategy}`, async () => {
+          // when
+          const res = await fetchHttps(path, { method });
+
+          // then
+          assert.equal(res.status, 200);
+
+          // and
+          assertCacheStrategyApplied(res, expectedCacheStrategy);
+      })
+    })
+  })
 
   describe('enketo caching', () => {
     [

--- a/test/nginx/test-nginx.js
+++ b/test/nginx/test-nginx.js
@@ -644,9 +644,9 @@ function assertCacheStrategyApplied(res, expectedCacheStrategy) {
       assert.equal(res.headers.get('Pragma'), 'no-cache');
       break;
     case 'passthrough':
-      expect(res).to.not.have.header('Cache-Control');
-      expect(res).to.not.have.header('Vary');
-      expect(res).to.not.have.header('Pragma');
+      expect(res.headers).to.not.have.property('Cache-Control');
+      expect(res.headers).to.not.have.property('Vary');
+      expect(res.headers).to.not.have.property('Pragma');
       break;
     default: throw new Error(`Unrecognised cache strategy: ${expectedCacheStrategy}`);
   }

--- a/test/nginx/test-nginx.js
+++ b/test/nginx/test-nginx.js
@@ -445,9 +445,10 @@ describe('nginx config', () => {
 
           // and
           assertCacheStrategyApplied(res, expectedCacheStrategy);
-      })
-    })
-  })
+        });
+      });
+    });
+  });
 
   describe('enketo caching', () => {
     [

--- a/test/nginx/test-nginx.js
+++ b/test/nginx/test-nginx.js
@@ -1,6 +1,6 @@
 const tls = require('node:tls');
 const { Readable } = require('stream');
-const { assert } = require('chai');
+const { assert, expect } = require('chai');
 
 const none = `'none'`;
 const self = `'self'`;

--- a/test/nginx/test-nginx.js
+++ b/test/nginx/test-nginx.js
@@ -378,6 +378,10 @@ describe('nginx config', () => {
       [ '/robots.txt',               'revalidate' ],
       [ '/version.txt',              'revalidate' ],
 
+      // central-backend
+      [ '/v1/foo',                   'passthrough' ],
+      [ '/v1/foo/bar/baz',           'passthrough' ],
+
       // central-frontend - unversioned
       [ '/',                         'revalidate' ],
       [ '/index.html',               'revalidate' ],
@@ -622,6 +626,11 @@ function assertCacheStrategyApplied(res, expectedCacheStrategy) {
       assert.equal(res.headers.get('Cache-Control'), 'no-store');
       assert.equal(res.headers.get('Vary'), '*');
       assert.equal(res.headers.get('Pragma'), 'no-cache');
+      break;
+    case 'passthrough':
+      expect(res).to.not.have.header('Cache-Control');
+      expect(res).to.not.have.header('Vary');
+      expect(res).to.not.have.header('Pragma');
       break;
     default: throw new Error(`Unrecognised cache strategy: ${expectedCacheStrategy}`);
   }


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/1048

#### What has been done to verify that this works as intended?
Put it on the dev server. Verified that there's exactly one `Cache-Control` header and that it's set as expected.

#### Why is this the best possible solution? Were any other approaches considered?
We could also set the headers here to `private, no-cache`, etc. But then we'd be setting duplicate headers which could drift between nginx and backend. I think it's clearer to make caching headers clearly the backend's responsibility.

Note that this does not set the `Pragma` header for backend. I think we could do away with it altogether because it has been deprecated for a long time.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Backend responses should be cached in private caches. We should get 304s.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
