### PR TITLE
Save verbose language for docs

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -39,8 +39,6 @@ HTTPS_PORT=443
 # SENTRY_ORG_SUBDOMAIN=
 # SENTRY_KEY=
 # SENTRY_PROJECT=
-# Percent of requests to sample for Sentry performance tracing.
-# Number between 0 and 1.  Default is 0.1.  To disable, set to 0.
 # SENTRY_TRACE_RATE=
 
 # Optional: configure S3-compatible storage for binary files


### PR DESCRIPTION
I think we should put this stuff in the docs and not the config.

```
# Percent of requests to sample for Sentry performance tracing.
# Number between 0 and 1.  Default is 0.1.  To disable, set to 0.
```