### PR TITLE
Get version from each submodule

### DIFF
--- a/files/prebuild/write-version.sh
+++ b/files/prebuild/write-version.sh
@@ -5,9 +5,8 @@ shopt -s inherit_errexit
 {
   echo "versions:"
   echo "$(git rev-parse HEAD) ($(git describe --tags))"
-  git submodule foreach --quiet '
-    commit=$(git rev-parse HEAD)
-    tag=$(git describe --tags)
-    echo " $commit $path ($tag)"
-  '
+  git submodule foreach --quiet --recursive \
+    "commit=\$(git rev-parse HEAD); \
+     tag=\$(git describe --tags); \
+     printf ' %s %s (%s)\n' \"\$commit\" \"\$path\" \"\$tag\""
 } > /tmp/version.txt

--- a/files/prebuild/write-version.sh
+++ b/files/prebuild/write-version.sh
@@ -8,6 +8,6 @@ shopt -s inherit_errexit
   git submodule foreach --quiet '
     commit=$(git rev-parse HEAD)
     tag=$(git describe --tags)
-    echo " $commit $name ($tag)"
+    echo " $commit $path ($tag)"
   '
 } > /tmp/version.txt

--- a/files/prebuild/write-version.sh
+++ b/files/prebuild/write-version.sh
@@ -2,4 +2,12 @@
 set -o pipefail
 shopt -s inherit_errexit
 
-{ echo "versions:"; echo "$(git rev-parse HEAD) ($(git describe --tags))"; git submodule; } > /tmp/version.txt
+{
+  echo "versions:"
+  echo "$(git rev-parse HEAD) ($(git describe --tags))"
+  git submodule foreach --quiet '
+    commit=$(git rev-parse HEAD)
+    tag=$(git describe --tags)
+    echo " $commit $name ($tag)"
+  '
+} > /tmp/version.txt


### PR DESCRIPTION
Closes #1085 

On upgraded server, I get the correct version
```
versions:
4ac522b9ad99ae30ce009a2cbb4c42f1535c561f (v2025.1.1)
 550c13d1935a6d33288e6cc00ee9068060bbf810 client (v2025.1.1)
 4ea612178d7eb9ef191e8548ef5e70c2084fa8fc server (v2025.1.0)
```

On staging, I get the correct version
```
versions:
721d2d4271724702263e44e0331fa2c6c99b979f (v2025.1.1-1-g721d2d4)
 550c13d1935a6d33288e6cc00ee9068060bbf810 client (v2025.1.1)
 4ea612178d7eb9ef191e8548ef5e70c2084fa8fc server (v2025.1.0)
```