### PR TITLE
Fix: remove edit submission redirection from the nginx config

### DIFF
--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -96,10 +96,6 @@ server {
     # Form fill link, public
     return 301 "/f/$enketoId$is_args$args";
   }
-  location ~ "^/-/edit/(?<enketoId>[a-zA-Z0-9]+)$" {
-    # Edit link
-    return 301 "/f/$enketoId/edit$is_args$args";
-  }
   location ~ "^/-/preview/(?<enketoId>[a-zA-Z0-9]+)$" {
     # preview link
     return 301 "/f/$enketoId/preview$is_args$args";

--- a/test/nginx/test-nginx.js
+++ b/test/nginx/test-nginx.js
@@ -202,10 +202,6 @@ describe('nginx config', () => {
       request: `/-/single/${enketoOnceId}?st=${sessionToken}`,
       expected: `f/${enketoOnceId}?st=${sessionToken}` },
 
-    { description: 'edit submission',
-      request: `/-/edit/${enketoId}?instance_id=uuid:123&return_url=https%3A%2F%2Fodk-nginx.example.test%2Fprojects%2F1%2Fforms%2Fsimple%2Fsubmissions%2Fuuid%3A123`,
-      expected: `f/${enketoId}/edit?instance_id=uuid:123&return_url=https%3A%2F%2Fodk-nginx.example.test%2Fprojects%2F1%2Fforms%2Fsimple%2Fsubmissions%2Fuuid%3A123` },
-
     { description: 'preview form',
       request: `/-/preview/${enketoId}`,
       expected: `f/${enketoId}/preview` },
@@ -246,6 +242,7 @@ describe('nginx config', () => {
     '/-/logout',
     '/-/api',
     '/-/preview',
+    '/-/edit/enketo-id'
   ].forEach(request => {
     it(`should not redirect ${request} to central-frontend`, async () => {
       // when


### PR DESCRIPTION
Adding `/-/edit/<enketo-id>` in the negative look ahead is not necessary because it doesn't matches `/-/[a-zA-Z0-9]+$` pattern.


#### Before submitting this PR, please make sure you have:

- [ ] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
