### PR TITLE
Fix: don't check enketo keys size when ENV is DEV

### DIFF
--- a/files/enketo/start-enketo.sh
+++ b/files/enketo/start-enketo.sh
@@ -25,9 +25,12 @@ assert_size() {
     exit 1
   fi
 }
-assert_size /etc/secrets/enketo-secret       64
-assert_size /etc/secrets/enketo-less-secret  32
-assert_size /etc/secrets/enketo-api-key     128
+
+if ! [[ "${ENV:-PROD}" = "DEV" ]]; then
+  assert_size /etc/secrets/enketo-secret       64
+  assert_size /etc/secrets/enketo-less-secret  32
+  assert_size /etc/secrets/enketo-api-key     128
+fi
 
 CONFIG_PATH=${ENKETO_SRC_DIR}/config/config.json
 log "Generating enketo configuration..."


### PR DESCRIPTION
Closes #1109

#### What has been done to verify that this works as intended?

Successfully started enketo container with `docker-compose.dev.yml`

#### Why is this the best possible solution? Were any other approaches considered?

`docker-compose.dev.yml` defines `ENV` variable equal to `DEV`, so it can be used in `start-enketo.sh` script, with a default value of `PROD`.

Another approach would be to use a predefined key with a proper size of 128 bytes instead of `enketorules`, but it must be done across configs and is a kind of breaking change (for development environment).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

It doesn't affect users because if `ENV` variable isn't defined, keys will be validated as before.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/git odk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced