### PR TITLE
Fix: set PostgreSQL credentials in dev config to be the same as in se…

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,9 +12,18 @@ services:
       - central
     ports:
       - 5432:5432
+    environment:
+      POSTGRES_USER: jubilant
+      POSTGRES_PASSWORD: jubilant
+      POSTGRES_DB: jubilant
   postgres:
     profiles:
       - central
+    environment:
+      PGUSER: jubilant
+      POSTGRES_INITDB_ARGS: -U jubilant
+      POSTGRES_PASSWORD: jubilant
+      POSTGRES_DB: jubilant
     image: debian:bullseye
     command: /bin/sh -c 'mkdir -p /var/lib/postgresql/14/data && touch /var/lib/postgresql/14/.postgres14-upgrade-successful'
   mail:


### PR DESCRIPTION
Closes #1111

#### What has been done to verify that this works as intended?

Successfully started PostgreSQL container with docker-compose.dev.yml (`make dev`) and run migrations (`cd server && make`)

#### Why is this the best possible solution? Were any other approaches considered?

It synchronizes credentials across docker and server configs. Another approach would be to change credentials in server config or guide developers to change them manually.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Doesn't affect users.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
