### PR TITLE
Feature: Add devcontainer support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,41 @@
+ARG node_version=22.14.0
+
+
+
+FROM node:${node_version}-slim AS pgdg
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        gpg \
+    && rm -rf /var/lib/apt/lists/* \
+    && update-ca-certificates
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(grep -oP 'VERSION_CODENAME=\K\w+' /etc/os-release)-pgdg main" \
+      | tee /etc/apt/sources.list.d/pgdg.list \
+    && curl https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+      | gpg --dearmor > /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg
+
+
+
+# Use regular image instead of slim
+FROM node:${node_version}
+
+ARG node_version
+LABEL org.opencontainers.image.source="https://github.com/getodk/central"
+
+COPY --from=pgdg /etc/apt/sources.list.d/pgdg.list \
+    /etc/apt/sources.list.d/pgdg.list
+COPY --from=pgdg /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg \
+    /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        gpg \
+        cron \
+        wait-for-it \
+        procps \
+        postgresql-client-14 \
+        netcat-traditional \
+        git \
+        make \
+        nginx \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,51 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-docker-compose
+{
+	"name": "ODK",
+
+	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
+	// The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
+	"dockerComposeFile": [
+		"../docker-compose.yml",
+		"../docker-compose.dev.yml",
+		"docker-compose.yml"
+	],
+
+	// The 'service' property is the name of the service for the container that VS Code should
+	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
+	"service": "service",
+
+	// The optional 'workspaceFolder' property is the path VS Code should open by default when
+	// connected. This is typically a file mount in .devcontainer/docker-compose.yml
+	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line if you want start specific services in your Docker Compose config.
+	"runServices": [
+		"postgres14",
+		"service",
+		"pyxform",
+		"secrets",
+		"enketo",
+		"enketo_redis_main",
+		"enketo_redis_cache"
+	],
+	"features": {}
+
+	// Uncomment the next line if you want to keep your containers running after VS Code shuts down.
+	// "shutdownAction": "none",
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "cat /etc/os-release",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "devcontainer"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,57 @@
+# devcontainers don't support profiles, so we reset them.
+version: '3.8'
+services:
+  # Update this to the name of the service you want to work with in your docker-compose.yml file
+  service:
+    # Uncomment if you want to override the service's Dockerfile to one in the .devcontainer 
+    # folder. Note that the path of the Dockerfile and context is relative to the *primary* 
+    # docker-compose.yml file (the first in the devcontainer.json "dockerComposeFile"
+    # array). The sample below assumes your primary file is in the root of your project.
+    #
+    build:
+      context: .
+      dockerfile: .devcontainer/Dockerfile
+
+    volumes: !override
+      # Update this to wherever you want VS Code to mount the folder of your project
+      - ..:/workspaces:cached
+      # Mount secrets
+      - dev_secrets:/etc/secrets
+
+    # Uncomment the next four lines if you will use a ptrace-based debugger like C++, Go, and Rust.
+    # cap_add:
+    #   - SYS_PTRACE
+    # security_opt:
+    #   - seccomp:unconfined
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+ 
+    profiles: !reset
+
+    # because enketo needs to see odk and
+    # nginx inside service needs to see enketo
+    network_mode: service:enketo
+
+  postgres14:
+    profiles: !reset
+    ports: !reset
+    network_mode: service:enketo
+    # just run database as usual, without upgrading
+    command: docker-entrypoint.sh postgres
+  postgres:
+    profiles: !reset
+  nginx:
+    profiles: !reset
+  mail:
+    profiles: !reset
+  pyxform:
+    profiles: !reset
+  secrets:
+    profiles: !reset
+  enketo:
+    profiles: !reset
+  enketo_redis_main:
+    profiles: !reset
+  enketo_redis_cache:
+    profiles: !reset

--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ If you want to work on the Central codebase and don't want to setup dependent se
 * Add an entry in your `/etc/hosts` file for `127.0.0.1 central-dev`.
 * Create `local.json` in the central-backend directory and set the value of `default.env.domain` to `http://central-dev:8989`
 
+### Development container
+
+Another option to get complete development environment is to use a development container in Docker.
+
+To start it in Visual Studio Code, follow these steps.
+Clone the repository.
+Copy the file `.env.template` to `.env`, and set `DOMAIN=local` and `SSL_TYPE=selfsign` (domain names won't work with Docker Desktop).
+Open command palette (press `Ctrl+Shift+P`) and select **Dev Containers: Reopen in Container**.
+
+After the container has started, you can open terminal inside Visual Studio Code and start server and client according to the documentation.
+
 ## Operations
 This repository serves administrative functions, but it also contains the Docker code for building and running a production Central stack.
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,9 +12,18 @@ services:
       - central
     ports:
       - 5432:5432
+    environment:
+      POSTGRES_USER: jubilant
+      POSTGRES_PASSWORD: jubilant
+      POSTGRES_DB: jubilant
   postgres:
     profiles:
       - central
+    environment:
+      PGUSER: jubilant
+      POSTGRES_INITDB_ARGS: -U jubilant
+      POSTGRES_PASSWORD: jubilant
+      POSTGRES_DB: jubilant
     image: debian:bullseye
     command: /bin/sh -c 'mkdir -p /var/lib/postgresql/14/data && touch /var/lib/postgresql/14/.postgres14-upgrade-successful'
   mail:

--- a/files/enketo/start-enketo.sh
+++ b/files/enketo/start-enketo.sh
@@ -25,9 +25,12 @@ assert_size() {
     exit 1
   fi
 }
-assert_size /etc/secrets/enketo-secret       64
-assert_size /etc/secrets/enketo-less-secret  32
-assert_size /etc/secrets/enketo-api-key     128
+
+if ! [[ "${ENV:-PROD}" = "DEV" ]]; then
+  assert_size /etc/secrets/enketo-secret       64
+  assert_size /etc/secrets/enketo-less-secret  32
+  assert_size /etc/secrets/enketo-api-key     128
+fi
 
 CONFIG_PATH=${ENKETO_SRC_DIR}/config/config.json
 log "Generating enketo configuration..."


### PR DESCRIPTION
# Blocked by:

* #1110
* #1112 

---

Our team recently started working with ODK, and it wasn't easy for novice developers to run a development environment. We've successfully used [devcontainers](https://code.visualstudio.com/docs/devcontainers/containers) in other projects for a reproducible development environment and working on a server. This is the config we are using.

This PR includes commits from PRs #1110 and #1112 to make it works.

Also, it requires next changes to Vite config in client https://github.com/getodk/central-frontend/pull/1274

#### What has been done to verify that this works as intended?

Started dev container using Visual Studio Code as per updated README.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
