### PR TITLE
chore: add GitHub Action workflow to close issues after merging to "next"

### DIFF
--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -1,0 +1,46 @@
+name: Close Issues on PR Merge to Next
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  close_issues:
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'next'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
+
+    steps:
+      - name: Parse and close linked issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || "";
+            const closedIssues = new Set();
+            const issueRegex = /(Closes|Fixes|Resolves)\s*:?\s+#(\d+)/gi;
+            let match;
+            
+            while ((match = issueRegex.exec(body)) !== null) {
+              const issueNumber = Number(match[2]);
+              if (!closedIssues.has(issueNumber)) {
+                closedIssues.add(issueNumber);
+                try {
+                  await github.rest.issues.update({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber,
+                    state: 'closed'
+                  });
+                  console.log(`Closed issue #${issueNumber}`);
+                } catch (e) {
+                  console.error(`Could not automatically close issue #${issueNumber}. Skipping issue.`);
+                }
+              }
+            }
+
+            if (closedIssues.size === 0) {
+              console.log("No issues found to close.");
+            }

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ We would love your contributions to Central. If you have thoughts or suggestions
 
 ### Branches
 
-The `master` branch of this repository is a stable branch that users clone when they install Central in production. The `next` branch reflects ongoing development for the next version of Central. Note that this differs from the `central-backend` and `central-frontend` repositories, where `master` is the development branch. When submitting a pull request to this repository, please target the `next` branch unless the change is limited to documentation, such as the README, and include `Fixes #{issue-number}` or `Closes #{issue-number}` in the PR description to automatically close the related issue upon merging.
+The `master` branch of this repository is a stable branch that users clone when they install Central in production. The `next` branch reflects ongoing development for the next version of Central. Note that this differs from the `central-backend` and `central-frontend` repositories, where `master` is the development branch. 
+
+When submitting a pull request to this repository, please target the `next` branch unless the change is limited to documentation, such as the README, and include `Fixes #{issue-number}` or `Closes #{issue-number}` in the PR description to automatically close the related issue upon merging.
 
 ### Services
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ We would love your contributions to Central. If you have thoughts or suggestions
 
 ### Branches
 
-The `master` branch of this repository is a stable branch that users clone when they install Central in production. The `next` branch reflects ongoing development for the next version of Central. Note that this differs from the `central-backend` and `central-frontend` repositories, where `master` is the development branch. If you create a PR to this repository, please target the `next` branch unless you are only changing documentation like the readme.
+The `master` branch of this repository is a stable branch that users clone when they install Central in production. The `next` branch reflects ongoing development for the next version of Central. Note that this differs from the `central-backend` and `central-frontend` repositories, where `master` is the development branch. When submitting a pull request to this repository, please target the `next` branch unless the change is limited to documentation, such as the README, and include `Fixes #{issue-number}` or `Closes #{issue-number}` in the PR description to automatically close the related issue upon merging.
 
 ### Services
 


### PR DESCRIPTION
Closes #

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
