### PR TITLE
test/check-dockerfiles: included non-root dockerfiles

### DIFF
--- a/test/check-dockerfiles.sh
+++ b/test/check-dockerfiles.sh
@@ -4,7 +4,7 @@ shopt -s inherit_errexit
 
 log() { echo >&2 "[$(basename "$0")] $*"; }
 
-for dockerfile in ./*.dockerfile; do
+for dockerfile in $(git ls-files \*.dockerfile); do
   log "Checking $dockerfile ..."
   docker build --file "$dockerfile" --check .
 done


### PR DESCRIPTION
Previously untested:

* `test/nginx/mock-http-service.dockerfile`

Noted while working on #1119

Closes #

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
