### PR TITLE
test/nginx: fix enketo ID in test URL

### DIFF
--- a/test/nginx/test-nginx.js
+++ b/test/nginx/test-nginx.js
@@ -242,7 +242,7 @@ describe('nginx config', () => {
     '/-/logout',
     '/-/api',
     '/-/preview',
-    '/-/edit/enketo-id'
+    '/-/edit/enketoid'
   ].forEach(request => {
     it(`should not redirect ${request} to central-frontend`, async () => {
       // when


### PR DESCRIPTION
According to current nginx rules, a valid enketo ID cannot include a - character.

#### What has been done to verify that this works as intended?

Existing tests.

#### Why is this the best possible solution? Were any other approaches considered?

Maybe both examples could be included?  But `enketo-id` does not seem like it should match any `enketoId` capture groups in the nginx config.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No change - it's a test case.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [ ] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
