### PR TITLE
Use pyxform version 3.1.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,7 @@ services:
       options:
         max-file: "30"
   pyxform:
-    image: 'ghcr.io/getodk/pyxform-http:v4.0.0'
+    image: 'ghcr.io/getodk/pyxform-http:v3.1.0'
     restart: always
   secrets:
     volumes:


### PR DESCRIPTION
Rolls back pyxform because of an Enketo issue with escaped newlines.

#### What has been done to verify that this works as intended?
Put this on dev, converted [multiline-calc.xlsx](https://github.com/user-attachments/files/20684343/multiline-calc.xlsx) and [editable.xlsx](https://github.com/user-attachments/files/20684345/editable.xlsx) to verify that client_editable is supported and newlines are not escaped to html entities.

#### Why is this the best possible solution? Were any other approaches considered?
We considered rolling back the pyxform update to 3.0.0. But that wouldn't give us `client_editable` which we wanted to have out. We considered rolling back the pyxform change that started escaping newlines but there's one other risky piece of work in 4.0.0 and we'd rather have a fully safe release for now.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
We now consider this very low risk.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
