### PR TITLE
Fixes: Cache strategy for public offline Enketo Forms

### DIFF
--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -35,7 +35,7 @@ map "$request_method::$uri$is_args$args" $cache_strategy {
   ~^(GET|HEAD)::/-(/x)?/js/build/chunks/     "immutable";
   ~^(GET|HEAD)::/-(/x)?/js/build/            "revalidate";
   ~^(GET|HEAD)::/-(/x)?/locales/             "revalidate";
-  ~^(GET|HEAD)::/-/x/[a-zA-Z0-9]+$           "revalidate";
+  ~^(GET|HEAD)::/-/x/[a-zA-Z0-9]+            "revalidate";
   ~^(GET|HEAD)::/-/x/offline-app-worker\.js$ "revalidate";
 
   default "single-use";

--- a/test/nginx/test-nginx.js
+++ b/test/nginx/test-nginx.js
@@ -479,6 +479,8 @@ describe('nginx config', () => {
       [ '/-/transform/xform/some-id',                      'single-use' ],
       [ '/-/submission/max-size/some-id',                  'single-use' ],
       [ '/-/x/0n1W082ZWvx1O7XDsmHNqfwSrIjeeIH',            'revalidate' ], // offline Form
+      [ '/-/x/0n1W082ZWvx1O7XDsmHNqfwSrIjeeIH?st=ieLWu5eDOZlx5LgYmigfSVo2tDVAyca3gaZs%24t3qJcPBLJmrnmzkzw5rH9pl%21OaJ',
+                                                           'revalidate' ], // offline public Form
       [ '/-/x/fonts/OpenSans-Bold-webfont.woff',           'revalidate' ],
       [ '/-/x/fonts/OpenSans-Regular-webfont.woff',        'revalidate' ],
       [ '/-/x/fonts/fontawesome-webfont.woff?v=4.6.2',     'immutable'  ],


### PR DESCRIPTION
Removed $ from the enketo cache strategy regex so that enketo offline line works with query parameter suffix as well

Closes [forum post](https://forum.getodk.org/t/after-upgrade-to-v-2025-2-1-public-access-link-of-forms-are-not-working-in-offline-mode/55810)

#### What has been done to verify that this works as intended?

Added a test and manual verification on dev environment.

#### Why is this the best possible solution? Were any other approaches considered?

Simple solution. I was thinking about using regex with optional query parameters but that would make the regex complex without any benefits.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
