### PR TITLE
use postgis/postgis:14-3.5 drop-in replacement for postgres:14.10 image

### DIFF
--- a/postgres14.dockerfile
+++ b/postgres14.dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:14.10
+FROM postgis/postgis:14-3.5
 
 COPY files/postgres14/start-postgres.sh /usr/local/bin/
 


### PR DESCRIPTION
Related: #1165
Related: getodk/central-backend#1555

With getodk/central-backend#1555 we'll need the PostGIS extensions in the DB container. This makes that happen.

#### What has been done to verify that this works as intended?

Ran the previous setup, checked locale provider, ran the new setup with same DB files, checked locale provider (matched, unsurprisingly, as [postgis/postgis](https://hub.docker.com/r/postgis/postgis) base themselves on [_/postgres](https://registry.hub.docker.com/_/postgres/)), nothing weird in the logs, data still there, and I can run `create extension postgis`.

#### Why is this the best possible solution? Were any other approaches considered?

I can't imagine anything simpler/easier than using the drop-in.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Using the drop-in replacement by itself shouldn't really _do_ anything, other than allowing one to install the PostGIS extension. 

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No getodk/docs update needed, but getodk/central-backend#1555 has a README.md update for those not using the Docker images.


#### Before submitting this PR, please make sure you have:

- [X] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [X] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
