### PR TITLE
nginx: enable HTTP2

### DIFF
--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -61,6 +61,7 @@ map $cache_strategy $cache_header_vary {
 
 server {
   listen 443 ssl;
+  http2 on;
   server_name ${DOMAIN};
 
   ssl_certificate /etc/${SSL_TYPE}/live/${CERT_DOMAIN}/fullchain.pem;


### PR DESCRIPTION
Closes #1309

#### What has been done to verify that this works as intended?

Manual testing on test instance.

#### Why is this the best possible solution? Were any other approaches considered?

The only other approach attempted was `listen 443 ssl http2`, but this seems to be deprecated syntax.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

* it should improve performance for users, but on lossy networks it may have the opposite effect
* it might increase the number of concurrent connections to node, using more server RAM

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No - any HTTP1-only clients should still continue to function as before; HTTP2-supporting clients like web browsers should get improved performance transparent to the user.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
