### PR TITLE
Fix: redirection for Enketo based on st parameter

### DIFF
--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -59,26 +59,19 @@ map $cache_strategy $cache_header_vary {
   default      "*";
 }
 
-map $args $args_without_single {
-  ~^single=[^&]*&?(.*)$ $1;
-  ~^(.*)&single=[^&]*&?(.*)$ $1&$2;
-  ~^(.*)&single=[^&]*$ $1;
-  default $args;
-}
-
-map $args_without_single $is_args_without_single {
+map $args $qp_deliminator {
   ~.+ "&";
-  default "";
+  default "?";
 }
 
 map $arg_st $redirect_non_single_prefix {
-  ~.+     "?single=false$is_args_without_single$args_without_single";
-  default "/new$is_args$args";
+  ~.+     "${is_args}${args}${qp_deliminator}single=false";
+  default "/new${is_args}${args}";
 }
 
 map $arg_st $redirect_single_prefix {
-  ~.+     "$is_args$args";
-  default "/new?single=true$is_args_without_single$args_without_single";
+  ~.+     "${is_args}${args}";
+  default "/new${is_args}${args}${qp_deliminator}single=true";
 }
 
 server {
@@ -117,7 +110,7 @@ server {
   location ~ "^/-/single/(?<enketoId>[a-zA-Z0-9]+)$" {
     # Form fill link, public
     # If 'st' query parameter is not present, redirect to protected route with single only
-    # end-of-form behavior (/new/single)
+    # end-of-form behavior (/new?single=true)
     return 301 "/f/$enketoId$redirect_single_prefix";
   }
   location ~ "^/-/preview/(?<enketoId>[a-zA-Z0-9]+)$" {
@@ -129,7 +122,7 @@ server {
   # we don't want them to be redirected to central-frontend
   location ~ "^/-/(?!thanks$|connection$|login$|logout$|api$|preview$)(?<enketoId>[a-zA-Z0-9]+)$" {
     # Form fill link (non-public), or Draft
-    # If 'st' query parameter is present, redirect to /multiple route for public access
+    # If 'st' query parameter is present, add ?single=false for public access
     return 301 "/f/$enketoId$redirect_non_single_prefix";
   }
   # To read single submission cookies

--- a/test/nginx/test-nginx.js
+++ b/test/nginx/test-nginx.js
@@ -240,7 +240,7 @@ describe('nginx config', () => {
 
     { description: '/single removed from the public link to make it multiple submission Form',
       request: `/-/${enketoId}?st=${sessionToken}`,
-      expected: `f/${enketoId}?single=false&st=${sessionToken}` },
+      expected: `f/${enketoId}?st=${sessionToken}&single=false` },
   ];
   enketoRedirectTestData.forEach(t => {
     it('should redirect old enketo links to central-frontend; ' + t.description, async () => {


### PR DESCRIPTION
Builds on https://github.com/getodk/central-frontend/pull/1325.

It solves the issue mentioned in https://forum.getodk.org/t/public-access-links-with-last-saved-not-working-as-expected-in-enketo-in-central-v2025-2/56351 where old public with `/single` prefix removed is redirected to the login page.

#### What has been done to verify that this works as intended?

Added tests and manually verified the change.

#### Why is this the best possible solution? Were any other approaches considered?

Besides checking existence of `st` query parameter we don't have anything to know the intention of the users.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

None

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

https://github.com/getodk/docs/issues/1985

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
