### PR TITLE
Enable HTTP3 with HTTP2 fallback

### DIFF
--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -60,7 +60,8 @@ map $cache_strategy $cache_header_vary {
 }
 
 server {
-  listen 443 ssl;
+  listen 443 quic reuseport;
+  listen 443 ssl http2;
   server_name ${DOMAIN};
 
   ssl_certificate /etc/${SSL_TYPE}/live/${CERT_DOMAIN}/fullchain.pem;
@@ -75,6 +76,7 @@ server {
 
   server_tokens off;
 
+  add_header Alt-Svc 'h3=":443"; ma=86400; persist=1' always;
   add_header Content-Security-Policy-Report-Only "default-src 'none'; connect-src https://translate.google.com https://translate.googleapis.com; img-src https://translate.google.com; report-uri /csp-report";
   include /usr/share/odk/nginx/common-headers.conf;
 


### PR DESCRIPTION
HTTP3 will perform better than HTTP2 with mobile devices. This PR enables HTTP3 with a fallback to HTTP2. 

Risks
- This will require allowing UDP traffic on port 443, so we'll need to update the docs. If folks don't open the port, clients will automatically fall back to HTTP2.
- In my research, HTTP2 might be slightly worse than HTTP1 for Collect (serialized gets/posts), but it shouldn't be noticeable. If we start parallelizing, then the TCP head-of-line blocking of HTTP2 could be a problem.

I think we should close https://github.com/getodk/central/pull/1310 in favor of this one.