### PR TITLE
Increase gzip level and types

### DIFF
--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -81,10 +81,12 @@ server {
   client_max_body_size 100m;
 
   gzip on;
+  gzip_comp_level 5;
   gzip_vary on;
-  gzip_min_length 1280;
+  gzip_min_length 1024;
   gzip_http_version 1.1;
-  gzip_types text/plain text/css application/json application/x-javascript application/javascript text/xml text/csv;
+  gzip_types text/plain text/css application/json application/geo+json application/x-javascript application/javascript text/xml text/csv image/svg+xml;
+  gzip_proxied any;
 
   # Enketo Configuration.
   # Enketo express is traditionally served at /- but with the introduction of ODK Web Forms


### PR DESCRIPTION
gzip_comp_level of 4-6 seems to be the sweet spot for compression and CPU usage. We don't often see huge CPU usage on servers so 5 seems pretty safe. 

gzip_proxied makes sure to gzip anything coming from upstream (reverse proxy mode)

gzip_min_length 1024 is a common default. 1280 suggests we've profiled the responses and we are making a sensible choice, but we haven't. Might as well use the common default.

I've added geojson and svg because we'll be serving those in the future.