### PR TITLE
docs(readme): clarify branch policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,13 @@ If you are looking for help, please take a look at the [Documentation Website](h
 
 We would love your contributions to Central. If you have thoughts or suggestions, please share them with us on the [Ideas board](https://forum.getodk.org/c/ideas) on the ODK Forum. If you wish to contribute code, you have the option of working on the Backend server ([contribution guide](https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md)), the Frontend website ([contribution guide](https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md)), or both. To set up a development environment, first follow the [Backend instructions](https://github.com/getodk/central-backend#setting-up-a-development-environment) and then optionally the [Frontend instructions](https://github.com/getodk/central-frontend#setting-up-your-development-environment).
 
-### Branches
 
-The `master` branch of this repository is a stable branch that users clone when they install Central in production. The `next` branch reflects ongoing development for the next version of Central. Note that this differs from the `central-backend` and `central-frontend` repositories, where `master` is the development branch. If you create a PR to this repository, please target the `next` branch unless you are only changing documentation like the readme.
+### Branches
+- `master` — stable production branch.
+- `next` — active development for the next release.
+
+Note: in `central-backend` and `central-frontend` the `master` branch is used for development.  
+For this repo, **target `next` for code PRs**; target `master` for documentation-only changes.
 
 ### Services
 


### PR DESCRIPTION
Closes #

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced

This PR improves the README Branches section for clarity:
- `master` = stable production branch
- `next` = active development branch
- Code PRs should target `next`
- Documentation-only PRs (like this one) should target `master`

