### PR TITLE
ci: use npm clean-install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: 22.16.0
-    - run: cd test/nginx && npm i
+    - run: cd test/nginx && npm clean-install
     - run: cd test/nginx && npm run lint
     - run: cd test/nginx && ./run-tests.sh
 

--- a/test/nginx/mock-http-service.dockerfile
+++ b/test/nginx/mock-http-service.dockerfile
@@ -3,5 +3,5 @@ FROM node:20.12.2-slim
 WORKDIR /workspace
 
 COPY ./mock-http-server .
-RUN npm install
+RUN npm clean-install
 ENTRYPOINT ["npm", "run", "start"]


### PR DESCRIPTION
From https://docs.npmjs.com/cli/v11/commands/npm-ci

> This command is similar to npm install, except it's meant to be used in automated environments such as test platforms, continuous integration, and deployment -- or any situation where you want to make sure you're doing a clean install of your dependencies.

Closes #

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
