### PR TITLE
Gzip application/xml in addition to text/xml

### DIFF
--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -100,7 +100,7 @@ server {
   gzip_vary on;
   gzip_min_length 1024;
   gzip_http_version 1.1;
-  gzip_types text/plain text/css application/json application/geo+json application/x-javascript application/javascript text/xml text/csv image/svg+xml;
+  gzip_types text/plain text/css application/json application/geo+json application/x-javascript application/javascript text/xml application/xml text/csv image/svg+xml;
   gzip_proxied any;
 
   # Enketo Configuration.


### PR DESCRIPTION
We currently gzip responses that are text/xml. Backend returns text/xml for a number of endpoints, including OpenRosa endpoints. However, in some cases, Backend returns application/xml. This PR makes sure that those responses are gzipped as well.

The following endpoints return application/xml:

- OData metadata documents (both submissions + entities)
- Non-OpenRosa form XML endpoint: /v1/projects/:projectId/forms/:xmlFormId.xml
- GET submission XML endpoint: /v1/projects/:projectId/forms/:xmlFormId/submissions/:instanceId.xml

#### Why is this the best possible solution? Were any other approaches considered?

We could also change Backend so that it always returns text/xml instead of application/xml. I'm not sure why the `Content-Type` is different for different endpoints. But even if we change Backend, I don't think it hurts to add application/xml to the gzip settings here. If there does end up being application/xml for some reason, I think it's good to gzip it.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
