### PR TITLE
Add cert that passes SSL checks

### DIFF
--- a/files/nginx/setup-odk.sh
+++ b/files/nginx/setup-odk.sh
@@ -12,15 +12,16 @@ fi
   < /usr/share/odk/nginx/client-config.json.template \
   > /usr/share/nginx/html/client-config.json
 
-# Generate self-signed keys for the incorrect (catch-all) HTTPS listener.  This
-# cert should never be seen by legitimate users, so it's not a big deal that
-# it's self-signed and won't expire for 1,000 years.
+# Generate self-signed keys for the incorrect (catch-all) HTTPS listener. This
+# cert should never be seen by legitimate users, but it needs to be X.509 v3
+# have subjectAltName and be reasonably valid to work with SSL scanners.
 mkdir -p /etc/nginx/ssl
 openssl req -x509 -nodes -newkey rsa:2048 \
-    -subj "/" \
+    -subj "/CN=invalid.local" \
+    -addext "subjectAltName=DNS:invalid.local" \
     -keyout /etc/nginx/ssl/nginx.default.key \
     -out    /etc/nginx/ssl/nginx.default.crt \
-    -days 365000
+    -days 3650
 
 DH_PATH=/etc/dh/nginx.pem
 if [ "$SSL_TYPE" != "upstream" ] && [ ! -s "$DH_PATH" ]; then


### PR DESCRIPTION
Currently, Central fails [SSL Labs'](https://www.ssllabs.com/ssltest/analyze.html?d=production.getodk.cloud) test with
> Assessment failed: Internal Server Error

People (including [us](https://docs.getodk.org/security/#hosting-considerations)) refer to this test to show that our configs are secure. The problem seems to be that the dummy cert we use is too dumb.  

#### What has been done to verify that this works as intended?
ChatGPT told me we need X.509 v3, a subjectAltName and be reasonably valid to work with SSL scanners, so I made those changes and confirmed that everything works.

<img width="1998" height="1122" alt="Screenshot 2025-09-16 at 18 58 40" src="https://github.com/user-attachments/assets/83973a7e-644e-419e-b5af-e0b1c1c970e4" />

The lack of SNI means we don't support these old browsers: Android 2.3.7, IE 6 / XP, IE 8 / XP, Java 6u45.

#### Why is this the best possible solution? Were any other approaches considered?

We could get rid of the dummy block that was added at https://github.com/getodk/central/pull/814 and make the real vhost the default. Not 100% sure why that was strictly necessary to begin with. 

We could also add do something like this...
```
server {
  listen 443 ssl default_server;
  server_name ${CERT_DOMAIN} _;

  ssl_certificate         /etc/${SSL_TYPE}/live/${CERT_DOMAIN}/fullchain.pem;
  ssl_certificate_key     /etc/${SSL_TYPE}/live/${CERT_DOMAIN}/privkey.pem;
  ssl_trusted_certificate /etc/${SSL_TYPE}/live/${CERT_DOMAIN}/fullchain.pem;

  ssl_protocols TLSv1.2 TLSv1.3;
  ssl_prefer_server_ciphers off;
  ssl_session_tickets off;

  # 🔒 Hard stop: only serve the real host
  if ($host != '${CERT_DOMAIN}') { return 421; }
```

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

It doesn't

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [X] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [X] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
