### PR TITLE
Use the gzip compression level most CDNs use

### DIFF
--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -96,7 +96,7 @@ server {
   client_max_body_size 100m;
 
   gzip on;
-  gzip_comp_level 5;
+  gzip_comp_level 6;
   gzip_vary on;
   gzip_min_length 1024;
   gzip_http_version 1.1;


### PR DESCRIPTION
We set to 5 out of an abundance of caution, but 6 is a much more common default. Unless there is a really good reason, we should just do what everyone else is doing as far as settings.