### PR TITLE
make dev: ensure running code is up-to-date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ docker-compose-dev := docker compose --profile central -f docker-compose.yml -f 
 
 .PHONY: dev
 dev:
-	$(docker-compose-dev) up -d
+	$(docker-compose-dev) up --detach --build
 
 .PHONY: stop
 stop:


### PR DESCRIPTION
Currently, `make dev` will not reflect local changes to docker config, files etc.

# This change:

The official `docker compose` docs ref the `--build` flag are scant: https://docs.docker.com/reference/cli/docker/compose/up/

However, behaviour seems to be that if `--build` is supplied, then containers with a `build:` section defined in any of the compose `yaml` files will be rebuilt.

This has the effect that changes in any of the following could trigger a rebuild:

* `files/`
* the relevant `.dockerfile`
* the compose `.yaml` file(s)

If no changes are detected, this "rebuild" seems to be just a fetch from the local cache.

#### What has been done to verify that this works as intended?

Tested this locally while trying to use `make dev` to speed up dev env setup.

#### Why is this the best possible solution? Were any other approaches considered?

It seems intuitive that `make dev` would serve recent changes to docker compose container contents and configuration!

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No change - dev only.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No change - dev only.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
