### PR TITLE
make dev: allow enketo to start

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -48,6 +48,7 @@ services:
       - enketo_redis_main
     environment:
       - ENV=DEV
+      - ENKETO_SECRETS=danger-insecure
     extra_hosts:
     - "${DOMAIN}:host-gateway"
     ports:

--- a/files/enketo/start-enketo.sh
+++ b/files/enketo/start-enketo.sh
@@ -4,7 +4,6 @@ shopt -s inherit_errexit
 
 log() { echo >&2 "[$(basename "$0")] $*"; }
 
-log "Checking secrets exist..."
 assert_size() {
   local f="$1"
   local expectedSize="$2"
@@ -25,9 +24,14 @@ assert_size() {
     exit 1
   fi
 }
-assert_size /etc/secrets/enketo-secret       64
-assert_size /etc/secrets/enketo-less-secret  32
-assert_size /etc/secrets/enketo-api-key     128
+if [[ "${ENKETO_SECRETS-}" = "danger-insecure" ]]; then
+  log "Skipping secrets check."
+else
+  log "Checking secrets exist..."
+  assert_size /etc/secrets/enketo-secret       64
+  assert_size /etc/secrets/enketo-less-secret  32
+  assert_size /etc/secrets/enketo-api-key     128
+fi
 
 CONFIG_PATH=${ENKETO_SRC_DIR}/config/config.json
 log "Generating enketo configuration..."


### PR DESCRIPTION
Currently `make dev` enketo startup will enter an endless restart loop, outputting:

```
enketo-1 exited with code 1 (restarting)
enketo-1  | [start-enketo.sh] Checking secrets exist...
enketo-1  | [start-enketo.sh] !!!
enketo-1  | [start-enketo.sh] !!! Unexpected file size:
enketo-1  | [start-enketo.sh] !!!   file: /etc/secrets/enketo-secret
enketo-1  | [start-enketo.sh] !!!   expected: 64 b
enketo-1  | [start-enketo.sh] !!!   actual:   18 b
enketo-1  | [start-enketo.sh] !!!
```

This commit removes enketo's check for secret sizes **when explicitly configured** to do so.

This is approach #​2 as discussed at https://github.com/getodk/central/pull/1110#issuecomment-2934268618

Closes #1109
Supersedes #1110

#### What has been done to verify that this works as intended?

Tested locally.  Change the value of `ENKETO_SECRETS` in `docker-compose.dev.yml` (or remove it completely) and then check:

```sh
docker compose --profile central -f docker-compose.yml -f docker-compose.dev.yml logs enketo
```

#### Why is this the best possible solution? Were any other approaches considered?

Discussion of other approaches at https://github.com/getodk/central/pull/1110#issuecomment-2934268618

This approach requires minimal changes to other repos, and reconfiguring of dev environments.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No change - dev only.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No - dev only.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
