### PR TITLE
Upgrade smtp container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       POSTGRES_PASSWORD: odk
       POSTGRES_DB: odk
   mail:
-    image: "ixdotai/smtp:v0.5.4"
+    image: "registry.gitlab.com/egos-tech/smtp:1.1.1"
     volumes:
       - ./files/mail/rsa.private:/etc/exim4/dkim.key.temp:ro
     environment:


### PR DESCRIPTION
Closes #966

## What has been done to verify that this works as intended?

Setup a VPS with outbound port 25 open, major cloud providers block it and we need to send customer service request to get it unblocked :( I ended up using Contabo. 

Checked out this PR and verified that reset password email works.

<details>

<summary>Screenshots & logs</summary>

<img width="515" height="186" alt="image" src="https://github.com/user-attachments/assets/704d3905-8ec7-4796-825c-a5944bb709a8" />

```
mail-1  |   281 Connecting to gmail-smtp-in.l.google.com [173.194.195.27]:25 ...
mail-1  |   281 connected
mail-1  |   281   SMTP<< 220 mx.google.com ESMTP e9e14a558f8ab-430d070df2bsi144628145ab.12 - gsmtp
mail-1  |   281   SMTP>> EHLO odk2.redacted.com
mail-1  |   281   SMTP<< 250-mx.google.com at your service, [94.72.112.17]
mail-1  |   281          250-SIZE 157286400
mail-1  |   281          250-8BITMIME
mail-1  |   281          250-STARTTLS
mail-1  |   281          250-ENHANCEDSTATUSCODES
mail-1  |   281          250-PIPELINING
mail-1  |   281          250-CHUNKING
mail-1  |   281          250 SMTPUTF8
mail-1  |   281   SMTP>> STARTTLS
mail-1  |   281   SMTP<< 220 2.0.0 Ready to start TLS
mail-1  |   281   SMTP>> EHLO odk2.redacted.com
mail-1  |   281   SMTP<< 250-mx.google.com at your service, [94.72.112.17]
mail-1  |   281          250-SIZE 157286400
mail-1  |   281          250-8BITMIME
mail-1  |   281          250-ENHANCEDSTATUSCODES
mail-1  |   281          250-PIPELINING
mail-1  |   281          250-CHUNKING
mail-1  |   281          250 SMTPUTF8
mail-1  |   281   SMTP|> MAIL FROM:<no-reply@odk2.redacted.com> SIZE=2354
mail-1  |   281   SMTP|> RCPT TO:<redacted@gmail.com>
mail-1  |   281          will write message using CHUNKING
mail-1  |   281   SMTP+> BDAT 1993 LAST
mail-1  |   281   SMTP>> QUIT
mail-1  |   281   SMTP<< 250 2.1.0 OK e9e14a558f8ab-430d070df2bsi144628145ab.12 - gsmtp
mail-1  |   281   SMTP<< 250 2.1.5 OK e9e14a558f8ab-430d070df2bsi144628145ab.12 - gsmtp
mail-1  |   281   SMTP<< 250 2.0.0 OK e9e14a558f8ab-430d070df2bsi144628145ab.12 - gsmtp
mail-1  |   281   SMTP<< 221 2.0.0 closing connection e9e14a558f8ab-430d070df2bsi144628145ab.12 - gsmtp
mail-1  |   281 LOG: MAIN
mail-1  |   281   H=gmail-smtp-in.l.google.com [173.194.195.27] TLS error on connection (recv): The TLS connection was non-properly terminated.
mail-1  |   281   SMTP(close)>>
mail-1  |   281 cmdlog: '220:EHLO:250-:STARTTLS:220:EHLO:250-:MAIL|:RCPT|:BDAT+:QUIT:250:250:250:221'
mail-1  |   280 LOG: MAIN
mail-1  |   280   => redacted@gmail.com R=dnslookup T=remote_smtp H=gmail-smtp-in.l.google.com [173.194.195.27] X=TLS1.3:ECDHE_X25519__ECDSA_SECP256R1_SHA256__AES_256_GCM:256 CV=yes DN="CN=mx.google.com" K C="250 2.0.0 OK e9e14a558f8ab-430d070df2bsi144628145ab.12 - gsmtp"
```
</details>

**Change History:**

**From v0.5.4 to latest (0.7.7) in github under ix-ai:**
https://github.com/ix-ai/smtp/compare/v0.5.4...v0.7.7

- Base OS image upgraded
- Configurable DKIM Selector with `dkim` as default value
- Ability to use split-file configuration for Exim
- Documentation and a CI change


**From v1.0.0 to latest (1.1.1) in gitlab under egos-tech:** (v1.0.0 is equal to 0.7.7 of previous repo)
https://gitlab.com/egos-tech/smtp/-/compare/1.0.0...1.1.1?from_project_id=68893719

- Base OS image upgraded
- Documentation

None of the changes look breaking to me or require any configuration changes on our part.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
