### PR TITLE
Add translations for simplified Chinese to outdated-version.html

### DIFF
--- a/docs/outdated-version.html
+++ b/docs/outdated-version.html
@@ -66,6 +66,11 @@
         "sentence1": "Sasisha sasa ili kulinda data zako na kutumia vipengele vipya zaidi.",
         "sentence2": "Kama hutaki kudumisha Central, jaribu {OdkCloudLink}."
       },
+      "zh": {
+        "heading": "您使用的ODK Central版本过低",
+        "sentence1": "立即升级以保护您的资料，同时使用最新的功能。",
+        "sentence2": "如果您不想维护Central，请使用{OdkCloudLink}。"
+      },
       "zh-Hant": {
         "heading": "您使用的 ODK Central 版本明顯過時",
         "sentence1": "立即升級以保護您的資料並利用最新功能。",


### PR DESCRIPTION
As part of v2025.3.1, we are adding support for simplified Chinese for the first time. The `central` repo has translations in one file, outdated-version.html. This PR adds simplified Chinese to that file.

Note that the language tag that we're using for simplified Chinese is zh. The tag that we're using for traditional Chinese is zh-Hant. For more background on the addition of simplified Chinese, see getodk/central-frontend#1415.

#### Why is this the best possible solution? Were any other approaches considered?

I just copied the translations from the `ExtraTranslations` component in Frontend.

#### What has been done to verify that this works as intended?

I didn't actually try it out, I just copied the translations.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
