### PR TITLE
expose database pool's maximum size, fixes #494

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -49,3 +49,7 @@ HTTPS_PORT=443
 
 # Optional: configure web user login session lifetime (in seconds)
 # SESSION_LIFETIME=
+
+# Optional: configure the per-worker database pool size
+# DB_POOL_SIZE=
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,7 @@ services:
       - DB_HOST=${DB_HOST:-postgres14}
       - DB_USER=${DB_USER:-odk}
       - DB_PASSWORD=${DB_PASSWORD:-odk}
+      - DB_POOL_SIZE=${DB_POOL_SIZE:-10}
       - DB_NAME=${DB_NAME:-odk}
       - DB_SSL=${DB_SSL:-null}
       - EMAIL_FROM=${EMAIL_FROM:-no-reply@$DOMAIN}

--- a/files/service/config.json.template
+++ b/files/service/config.json.template
@@ -5,7 +5,8 @@
       "user": "${DB_USER}",
       "password": "${DB_PASSWORD}",
       "database": "${DB_NAME}",
-      "ssl": ${DB_SSL}
+      "ssl": ${DB_SSL},
+      "maximumPoolSize": ${DB_POOL_SIZE}
     },
     "email": {
       "serviceAccount": "${EMAIL_FROM}",


### PR DESCRIPTION
Exposes database pool's maximum size.

Closes #494

#### What has been done to verify that this works as intended?

- Verified that a config's `default.database.maximumPoolsize` actually has an effect. It does.
- CI

#### Why is this the best possible solution? Were any other approaches considered?

N/A

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

N/A

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No. We didn't do it for #1404 which is very similar. But [here](https://github.com/getodk/central/issues/1386#issuecomment-3569745800) I'm floating the idea of creating a scaling guide.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
