### PR TITLE
nginx/csp/blank.html: add missing reporting

### DIFF
--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -173,7 +173,7 @@ server {
     root /usr/share/nginx/html;
     try_files /blank.html =404;
 
-    add_header Content-Security-Policy-Report-Only "default-src 'none'";
+    add_header Content-Security-Policy-Report-Only "default-src 'none'; report-uri /csp-report";
     include /usr/share/odk/nginx/common-headers.conf;
   }
   location = /blank.html {

--- a/test/nginx/test-nginx.js
+++ b/test/nginx/test-nginx.js
@@ -43,6 +43,7 @@ const contentSecurityPolicies = {
   },
   'disallow-all': {
     'default-src': none,
+    'report-uri':  '/csp-report',
   },
   enketo: {
     'default-src': none,


### PR DESCRIPTION
Prompted by reviews from https://github.com/getodk/central/pull/1478.

Closes https://github.com/getodk/central/issues/1520.

#### What has been done to verify that this works as intended?

CI.

#### Why is this the best possible solution? Were any other approaches considered?

Without a report URI, violations will not be known, which would make switching from `Content-Security-Policy-Report-Only` to `Content-Security-Policy` risky.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
