### PR TITLE
nginx/csp: switch rules for API and blank.html

### DIFF
--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -163,7 +163,7 @@ server {
 
   location ~ ^/v\d {
     proxy_hide_header Content-Security-Policy-Report-Only;
-    add_header Content-Security-Policy-Report-Only "default-src 'none'; connect-src https://translate.google.com https://translate.googleapis.com; img-src https://translate.google.com; report-uri /csp-report";
+    add_header Content-Security-Policy-Report-Only "default-src 'none'; report-uri /csp-report";
 
     include /usr/share/odk/nginx/common-headers.conf;
     include /usr/share/odk/nginx/backend.conf;
@@ -173,7 +173,7 @@ server {
     root /usr/share/nginx/html;
     try_files /blank.html =404;
 
-    add_header Content-Security-Policy-Report-Only "default-src 'none'; report-uri /csp-report";
+    add_header Content-Security-Policy-Report-Only "default-src 'none'; connect-src https://translate.google.com https://translate.googleapis.com; img-src https://translate.google.com; report-uri /csp-report";
     include /usr/share/odk/nginx/common-headers.conf;
   }
   location = /blank.html {

--- a/test/nginx/test-nginx.js
+++ b/test/nginx/test-nginx.js
@@ -30,10 +30,6 @@ const allowGoogleTranslate = ({ 'connect-src':connectSrc, 'img-src':imgSrc, ...o
 });
 
 const contentSecurityPolicies = {
-  'backend-default': allowGoogleTranslate({
-    'default-src': none,
-    'report-uri':  '/csp-report',
-  }),
   'backend-unmodified': {
     'default-src': 'NOTE:FROM-BACKEND',
   },
@@ -61,6 +57,10 @@ const contentSecurityPolicies = {
     'default-src': none,
     'report-uri':  '/csp-report',
   },
+  'disallow-all-except-standard-plugins': allowGoogleTranslate({
+    'default-src': none,
+    'report-uri':  '/csp-report',
+  }),
   enketo: allowGoogleTranslate({
     'default-src': none,
     'connect-src': [
@@ -350,7 +350,7 @@ describe('nginx config', () => {
         assert.equal(res.status, 200);
         assert.isEmpty((await res.text()).trim());
         assert.equal(res.headers.get('Content-Type'), 'text/html');
-        assertSecurityHeaders(res, { csp:'disallow-all' });
+        assertSecurityHeaders(res, { csp:'disallow-all-except-standard-plugins' });
         await assertEnketoReceivedNoRequests();
       });
     });
@@ -363,7 +363,7 @@ describe('nginx config', () => {
     // then
     assert.equal(res.status, 200);
     assert.equal(await res.text(), 'OK');
-    assertSecurityHeaders(res, { csp:'backend-default' });
+    assertSecurityHeaders(res, { csp:'disallow-all' });
     // and
     await assertBackendReceived(
       { method:'GET', path:'/v1/some/central-backend/path' },
@@ -385,7 +385,7 @@ describe('nginx config', () => {
     const res = await fetchHttps('/v1/reflect-headers');
     // then
     assert.equal(res.status, 200);
-    assertSecurityHeaders(res, { csp:'backend-default' });
+    assertSecurityHeaders(res, { csp:'disallow-all' });
 
     // when
     const body = await res.json();
@@ -403,7 +403,7 @@ describe('nginx config', () => {
     // then
     assert.equal(res.status, 200);
     // and
-    assertSecurityHeaders(res, { csp:'backend-default' });
+    assertSecurityHeaders(res, { csp:'disallow-all' });
 
     // when
     const body = await res.json();


### PR DESCRIPTION
* `/blank.html` should allow Google Translate
* API endpoints should allow nothing, as they shouldn't be loaded as browser pages

Closes #1516
Closes #1517

#### What has been done to verify that this works as intended?

Updated test expectations.

#### Why is this the best possible solution? Were any other approaches considered?

The changes could be done separately.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
