### PR TITLE
Update X-Forwarded-Proto directive in backend.conf

### DIFF
--- a/files/nginx/setup-odk.sh
+++ b/files/nginx/setup-odk.sh
@@ -59,7 +59,7 @@ else
     # strip out all ssl_* directives
     perl -i -ne 's/listen 443.*/listen 80;/; print if ! /ssl_/' /etc/nginx/conf.d/odk.conf
     # force https because we expect SSL upstream
-    perl -i -pe 's/X-Forwarded-Proto \$scheme/X-Forwarded-Proto https/;' /etc/nginx/conf.d/odk.conf
+    perl -i -pe 's/X-Forwarded-Proto \$scheme/X-Forwarded-Proto https/;' /usr/share/odk/nginx/backend.conf
     echo "starting nginx for upstream ssl..."
   else
     # remove letsencrypt challenge reply, but keep 80 to 443 redirection


### PR DESCRIPTION
This PR fixes a regression in behavior reported on the ODK forum [here](https://forum.getodk.org/t/setting-up-central-behind-a-proxy-this-authentication-method-is-only-available-over-https/57236/10).  The regression was introduced in https://github.com/getodk/central/commit/924d320112b1e5d5929803a51f3bad7056d1295e during a code refactor.  The code refactor moved the `X-Forwarded-Proto` header to a new file but did not update the regexp which pins this header to `https` in `setup-odk.sh` script to point to that file.  The result is that HTTP authentication breaks for users hosting ODK behind a reverse proxy.

#### What has been done to verify that this works as intended?

I have made the changes on my local installation, rerun the docker compose build, and confirmed that the issues reported in [this forum post](https://forum.getodk.org/t/setting-up-central-behind-a-proxy-this-authentication-method-is-only-available-over-https/57236/10) are resolved.  I can log into my server without throwing the `httpsOnly()` error.

#### Why is this the best possible solution? Were any other approaches considered?

I believe this is a minor regression introduced during code refactoring in error.  This emulates the behavior of the build script before https://github.com/getodk/central/commit/924d320112b1e5d5929803a51f3bad7056d1295e.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This fixes a regression in behavior, and should not introduce more breakages.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
