### PR TITLE
getodk/central#1556: Upgrade redis to v8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,7 +138,7 @@ services:
       - SUPPORT_EMAIL=${SYSADMIN_EMAIL}
       - HTTPS_PORT=${HTTPS_PORT:-443}
   enketo_redis_main:
-    image: redis:7.4.7
+    image: redis:8.4.0
     volumes:
       - ./files/enketo/redis-enketo-main.conf:/usr/local/etc/redis/redis.conf:ro
       - enketo_redis_main:/data
@@ -147,7 +147,7 @@ services:
       - /usr/local/etc/redis/redis.conf
     restart: always
   enketo_redis_cache:
-    image: redis:7.4.7
+    image: redis:8.4.0
     volumes:
       - ./files/enketo/redis-enketo-cache.conf:/usr/local/etc/redis/redis.conf:ro
       - enketo_redis_cache:/data


### PR DESCRIPTION
Closes getodk/central#1556

#### What has been done to verify that this works as intended?

- All tests are passing
- Following manual verification done after upgrade:
  - Existing draft form works
  - Existing published Form works
  - Edit existing submissions work
  - Existing public link works
  - Existing single submission public link works
  - New form can be created and published
  - New submission can be made to the new Form
  - New submission is editable
  
#### Why is this the best possible solution? Were any other approaches considered?

NA

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Enketo express has quite an old redis client i.e. v3.1.2 which may not be fully compatible with the redis v8, but the usage is quite basic so it should be okay to upgrade.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
