### PR TITLE
ci/close-issues: support all official keywords

### DIFF
--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -20,7 +20,7 @@ jobs:
           script: |
             const body = context.payload.pull_request.body || "";
             const closedIssues = new Set();
-            const issueRegex = /(Closes|Fixes|Resolves)\s*:?\s+(?:(?:https:\/\/)?github.com\/getodk\/central\/issues\/|getodk\/central#|#)(\d+)/gi;
+            const issueRegex = /(Close|Closes|Closed|Fix|Fixes|Fixed|Resolve|Resolves|Resolved)\s*:?\s+(?:(?:https:\/\/)?github.com\/getodk\/central\/issues\/|getodk\/central#|#)(\d+)/gi;
             let match;
             
             while ((match = issueRegex.exec(body)) !== null) {

--- a/test/github-actions.spec.js
+++ b/test/github-actions.spec.js
@@ -12,8 +12,7 @@ describe('github-actions', () => {
     const workflowSrcPath = '.github/workflows/close-issues.yml';
 
     describe('issueRegex', () => {
-      const issueRegex = /(Closes|Fixes|Resolves)\s*:?\s+(?:(?:https:\/\/)?github.com\/getodk\/central\/issues\/|getodk\/central#|#)(\d+)/gi;
-
+      const issueRegex = /(Close|Closes|Closed|Fix|Fixes|Fixed|Resolve|Resolves|Resolved)\s*:?\s+(?:(?:https:\/\/)?github.com\/getodk\/central\/issues\/|getodk\/central#|#)(\d+)/gi;
       it('should have same form as the regex we test', () => {
         assert.equal(
           yaml.parse(readFileSync(`../${workflowSrcPath}`, 'utf8'))


### PR DESCRIPTION
Per suggestion at https://github.com/getodk/central/pull/1599#discussion_r2745419847

#### What has been done to verify that this works as intended?

Updated tests.

#### Why is this the best possible solution? Were any other approaches considered?

Aims for exact support for the same keywords as github would support in a normal default-branch setup.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
