### PR TITLE
check-docker-context: print report before running checks

### DIFF
--- a/test/check-docker-context.sh
+++ b/test/check-docker-context.sh
@@ -97,13 +97,6 @@ throw_err() {
   exit 1
 }
 
-log "File count: $file_count"
-if [[ "${skip_count-}" != "true" ]]; then
-  if [[ "$file_count" -lt "$min_count" ]] || [[ "$file_count" -gt "$max_count" ]]; then
-    throw_err "This is a surprising number of files - expected between $min_count and $max_count"
-  fi
-fi
-
 human_size() {
   if [[ "$1" -gt 999999 ]]; then
     echo "$(bc <<< "scale=3; $1 / 1000000") GB"
@@ -112,7 +105,15 @@ human_size() {
   fi
 }
 
+log "File count: $file_count"
 log "Total size: $(human_size "$total_size")"
+
+if [[ "${skip_count-}" != "true" ]]; then
+  if [[ "$file_count" -lt "$min_count" ]] || [[ "$file_count" -gt "$max_count" ]]; then
+    throw_err "This is a surprising number of files - expected between $min_count and $max_count"
+  fi
+fi
+
 if [[ "${skip_size-}" != "true" ]]; then
   # N.B. busybox `du` outputs in kB
   # See: https://www.busybox.net/downloads/BusyBox.html#du


### PR DESCRIPTION
This allows for full reporting before failure in the case of the first check failing.

Related: #948

#### What has been done to verify that this works as intended?

* ran locally
* ran in CI with file count failure
* ran in CI without failures

#### Why is this the best possible solution? Were any other approaches considered?

Simple.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
