### PR TITLE
check-docker-context: fix "No such image" error

### DIFF
--- a/test/check-docker-context.sh
+++ b/test/check-docker-context.sh
@@ -53,9 +53,8 @@ log "Building docker image..."
 iidfile="$(mktemp)"
 (
 docker \
-    buildx build \
+    buildx build --load \
     --iidfile "$iidfile" \
-    --load \
     --no-cache --progress plain --file - . 2>&1 <<EOF
 FROM busybox
 COPY . /build-context


### PR DESCRIPTION
Closes #1644

#### What has been done to verify that this works as intended?

Ran CI a lot.

#### Why is this the best possible solution? Were any other approaches considered?

Per https://github.com/getodk/central/issues/1644#issuecomment-3892616589:

> This with --iidfile is the documented expected behavior that scripts can rely on that we shouldn't break, as opposed to pattern matching from the output.  
> - _https://github.com/moby/buildkit/issues/1155#issuecomment-529658775_

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
