### PR TITLE
Log error after failing to close issue

### DIFF
--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -36,6 +36,7 @@ jobs:
                   });
                   console.log(`Closed issue #${issueNumber}`);
                 } catch (e) {
+                  console.error(e);
                   console.error(`Could not automatically close issue #${issueNumber}. Skipping issue.`);
                 }
               }


### PR DESCRIPTION
See the discussion at https://github.com/getodk/central/issues/1644#issuecomment-3916859288. The `close-issues` action sometimes fail, and we want to get more information in that case.

#### What has been done to verify that this works as intended?

Let's see what happens when I add this spurious line. After this PR is merged, we should see additional error logging.

Closes #1000000.

#### Why is this the best possible solution? Were any other approaches considered?

I thought about `throw`ing the error instead, but I don't know that that's any better. The `try`/`catch` is in a `while` loop, so maybe it's nice to allow the loop to continue iterating.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
