### PR TITLE
test-images: check contents of version.txt

### DIFF
--- a/test/test-images.sh
+++ b/test/test-images.sh
@@ -49,6 +49,18 @@ docker compose build
 log "Starting containers..."
 docker compose up --detach
 
+log "Verifying version.txt..."
+diff \
+     <(docker compose exec nginx cat /usr/share/nginx/html/version.txt) \
+     <(cat <<EOF
+versions:
+$(git rev-parse HEAD) ($(git describe --tags))
+ $(cd client && git rev-parse HEAD) client ($(cd client && git describe --tags))
+ $(cd server && git rev-parse HEAD) server ($(cd server && git describe --tags))
+EOF
+     )
+log "version.txt looks OK."
+
 log "Verifying frontend..."
 check_path 180 / 'ODK Central'
 log "  Frontend started OK."


### PR DESCRIPTION
Document expected contents of `version.txt` and allow future changes to be detected by a failing test.

Ref https://github.com/getodk/central/pull/738#discussion_r2820484541

#### What has been done to verify that this works as intended?

* ran the code locally and see it works
* ran in CI and inspected the output

#### Why is this the best possible solution? Were any other approaches considered?

It's questionable if the current behaviour is correct.  At least with a test in place this is visible, and future changes should be easier to verify.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced