### PR TITLE
git-describe: don't fail if tags missing

### DIFF
--- a/files/prebuild/write-version.sh
+++ b/files/prebuild/write-version.sh
@@ -4,9 +4,9 @@ shopt -s inherit_errexit
 
 {
   echo "versions:"
-  echo "$(git rev-parse HEAD) ($(git describe --tags))"
+  echo "$(git rev-parse HEAD) ($(git describe --tags --always))"
   git submodule foreach --quiet --recursive \
     "commit=\$(git rev-parse HEAD); \
-     tag=\$(git describe --tags); \
+     tag=\$(git describe --tags --always); \
      printf ' %s %s (%s)\n' \"\$commit\" \"\$path\" \"\$tag\""
 } > /tmp/version.txt

--- a/service.dockerfile
+++ b/service.dockerfile
@@ -24,11 +24,11 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 COPY . .
 RUN mkdir /tmp/sentry-versions
-RUN git describe --tags --dirty > /tmp/sentry-versions/central
+RUN git describe --tags --dirty --always > /tmp/sentry-versions/central
 WORKDIR /server
-RUN git describe --tags --dirty > /tmp/sentry-versions/server
+RUN git describe --tags --dirty --always > /tmp/sentry-versions/server
 WORKDIR /client
-RUN git describe --tags --dirty > /tmp/sentry-versions/client
+RUN git describe --tags --dirty --always > /tmp/sentry-versions/client
 
 
 

--- a/test/test-images.sh
+++ b/test/test-images.sh
@@ -54,9 +54,9 @@ diff \
      <(docker compose exec nginx cat /usr/share/nginx/html/version.txt) \
      <(cat <<EOF
 versions:
-$(git rev-parse HEAD) ($(git describe --tags))
- $(cd client && git rev-parse HEAD) client ($(cd client && git describe --tags))
- $(cd server && git rev-parse HEAD) server ($(cd server && git describe --tags))
+$(git rev-parse HEAD) ($(git describe --tags --always))
+ $(cd client && git rev-parse HEAD) client ($(cd client && git describe --tags --always))
+ $(cd server && git rev-parse HEAD) server ($(cd server && git describe --tags --always))
 EOF
      )
 log "version.txt looks OK."


### PR DESCRIPTION
Various commands running `git describe --tags` will fail if running in a repo (or submodule repo) which doesn't have the canonical repository's tags available.

This commit converts missing tags into git hashes, per `git-describe --always` docs:

> ```
> --always
>     Show uniquely abbreviated commit object as fallback.
> ```

Closes #1640

#### What has been done to verify that this works as intended?

* CI

#### Why is this the best possible solution? Were any other approaches considered?

It seems reasonable for CI to still pass on forks or when a submodule is changed to a fork.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No change.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
