### PR TITLE
Upgrade pyxform to 4.3.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,7 @@ services:
       options:
         max-file: "30"
   pyxform:
-    image: 'ghcr.io/getodk/pyxform-http:v4.2.0'
+    image: 'ghcr.io/getodk/pyxform-http:v4.3.0'
     restart: always
   secrets:
     volumes:


### PR DESCRIPTION
In preparation for release. Let's first get on `next` and then cherry-pick to hotfix branch.

I put the update on dev and verified that it has the new pyxform functionality and otherwise works.