### PR TITLE
csp/blank.html: prevent favicon violation

### DIFF
--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -183,7 +183,7 @@ server {
     root /usr/share/nginx/html;
     try_files /blank.html =404;
 
-    add_header Content-Security-Policy-Report-Only "default-src 'none'; connect-src https://translate.google.com https://translate.googleapis.com; img-src https://translate.google.com; report-uri /csp-report" always;
+    add_header Content-Security-Policy-Report-Only "default-src 'none'; connect-src https://translate.google.com https://translate.googleapis.com; img-src 'self' https://translate.google.com; report-uri /csp-report" always;
     include /usr/share/odk/nginx/common-headers.conf;
   }
   location = /blank.html {

--- a/test/nginx/test-nginx.js
+++ b/test/nginx/test-nginx.js
@@ -36,6 +36,11 @@ const contentSecurityPolicies = {
   'backend-unmodified': {
     'default-src': 'NOTE:FROM-BACKEND',
   },
+  'blank-html': allowGoogleTranslate({
+    'default-src': none,
+    'img-src': self, // allow favicon.ico
+    'report-uri':  '/csp-report',
+  }),
   'central-frontend': allowGoogleTranslate({
     'default-src':    none,
     'connect-src': [
@@ -63,10 +68,6 @@ const contentSecurityPolicies = {
     'default-src': none,
     'report-uri':  '/csp-report',
   },
-  'disallow-all-except-standard-plugins': allowGoogleTranslate({
-    'default-src': none,
-    'report-uri':  '/csp-report',
-  }),
   enketo: allowGoogleTranslate({
     'default-src': none,
     'connect-src': [
@@ -480,7 +481,7 @@ function standardTestSuite({ fetchHttp, fetchHttp6, apiFetch, apiFetch6, forward
         assert.equal(res.status, 200);
         assert.isEmpty((await res.text()).trim());
         assert.equal(res.headers.get('Content-Type'), 'text/html');
-        assertSecurityHeaders(res, { csp:'disallow-all-except-standard-plugins' });
+        assertSecurityHeaders(res, { csp:'blank-html' });
         await assertEnketoReceivedNoRequests();
       });
     });


### PR DESCRIPTION
* allow favicon
* rename policy, as it is no longer "disallowing all"

# Resolves:

## Firefox:

In `FaviconLoader.sys.mjs:224:20`:

```
Content-Security-Policy: (Report-Only policy) The page’s settings would block the loading of a resource (img-src) at https://dev.getodk.cloud/favicon.ico because it violates the following directive: “img-src https://translate.google.com”
```

## Chrome:

In `blank.html`:

```
Loading the image 'https://dev.getodk.cloud/favicon.ico' violates the following Content Security Policy directive: "img-src https://translate.google.com". The policy is report-only, so the violation has been logged but no further action has been taken.
```

#### What has been done to verify that this works as intended?

* updated tests

#### Why is this the best possible solution? Were any other approaches considered?

Could just ignore this - seems to currently be filtered on the Sentry side.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
