### PR TITLE
ci: update actions to node 24

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - run: docker --version
     - run: docker compose version
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - run: ./test/check-submodules.sh
     - run: sudo apt-get install shellcheck
     - run: ./test/check-scripts.sh
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 2
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
         fetch-tags: true
@@ -34,12 +34,12 @@ jobs:
     timeout-minutes: 2
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
         fetch-tags: true
         submodules: recursive
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v5
       with:
         node-version: 24.13.0
     - run: cd test/nginx && npm clean-install
@@ -60,7 +60,7 @@ jobs:
     timeout-minutes: 2
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - run: ./test/test-secrets.sh
   test-images:
     timeout-minutes: 10
@@ -71,7 +71,7 @@ jobs:
     - test-secrets
     runs-on: ubuntu-latest # TODO matrix to run on all expected versions?
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
         fetch-tags: true


### PR DESCRIPTION
Per https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/.

Resolves warning:

	Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-node@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

See:

* https://github.com/actions/checkout?tab=readme-ov-file#checkout-v5
* https://github.com/actions/setup-node?tab=readme-ov-file#breaking-changes-in-v5

#### What has been done to verify that this works as intended?

CI.

#### Why is this the best possible solution? Were any other approaches considered?

Could:

* remove the version number
* upgrade to v6 of each action

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect - just CI.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
