### PR TITLE
Enable HTTP/1.1 for nginx <-> backend

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,7 @@ jobs:
     - run: cd test/nginx && npm clean-install
     - run: cd test/nginx && ./setup-tests.sh
     - run: cd test/nginx && npm run test:nginx:mocha
+    - run: cd test/nginx && npm run test:nginx-chunked-stream-error-passthrough
     - run: cd test/nginx && ./lint-config.sh
 
     - run: cd test/nginx && npx playwright install --with-deps chromium-headless-shell

--- a/files/nginx/backend.conf
+++ b/files/nginx/backend.conf
@@ -6,3 +6,4 @@ proxy_redirect off;
 proxy_request_buffering on;
 proxy_buffering off;
 proxy_read_timeout 2m;
+proxy_http_version 1.1;  # because https://github.com/getodk/central/issues/1736

--- a/test/nginx/mock-http-server/index.js
+++ b/test/nginx/mock-http-server/index.js
@@ -9,7 +9,23 @@ const app = express();
 
 app.use((req, res, next) => {
   console.log(new Date(), req.method, req.originalUrl);
+  next();
+});
 
+app.get('/v1/chunked', (req, res) => {
+  // See https://github.com/getodk/central/issues/1736
+  // We don't have to set the transfer encoding to chunked explicitly; by default,
+  // node will produce a chunked response when we treat the response as a stream.
+  res.flushHeaders();
+  res.cork();
+  res.write('Pack it up, ');
+  res.uncork();
+  res.write('pack it in, ');
+  if (req.query.crash) throw new Error("let's pretend-play a bad thing happened and now we couldn't call .end() and thus we have an unterminated chunked stream on our hands.");
+  res.end('let me begin\n');
+});
+
+app.use((req, res, next) => {
   // always set CSP header to detect (or allow) leaks from backend through to the client
   res.set('Content-Security-Policy',             'default-src NOTE:FROM-BACKEND:block');
   res.set('Content-Security-Policy-Report-Only', 'default-src NOTE:FROM-BACKEND:reportOnly');

--- a/test/nginx/test-nginx-chunked-stream-error-passthrough.sh
+++ b/test/nginx/test-nginx-chunked-stream-error-passthrough.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -eu
+set -o pipefail
+shopt -s inherit_errexit
+
+set -e
+STREAM_URL="https://odk-nginx.example.test:9001/v1/chunked"
+BROKEN_STREAM_URL="${STREAM_URL}?crash=1"
+CURL="curl --resolve odk-nginx.example.test:9001:127.0.0.1 --insecure --fail --verbose --silent --show-error"
+
+# check completed stream on HTTP/1.1
+$CURL --http1.1 ${STREAM_URL}
+
+# check completed stream on HTTP/2
+$CURL --http2-prior-knowledge ${STREAM_URL}
+
+
+function check_broken_stream_detectable() {
+    set +e
+    $CURL "${1}" "${BROKEN_STREAM_URL}"
+    local curl_exitcode=${?}
+    set -e
+    if [[ $curl_exitcode -ne "${2}" ]]; then
+        printf "\n\n\nCrashed stream production should have been detected:\n\t— for http/1.1, with exitcode 18: \"Partial file. Only a part of the file was transferred.\"\n\t— for http/2, with exitcode 92: \"HTTP/2 stream 1 was not closed cleanly\"\n\n\n"
+        exit 1
+    fi
+}
+
+# check interrupted stream on HTTP/1.1
+check_broken_stream_detectable --http1.1 18
+
+# # check interrupted stream on HTTP/2
+check_broken_stream_detectable --http2-prior-knowledge 92

--- a/test/package.json
+++ b/test/package.json
@@ -6,7 +6,8 @@
     "test:nginx": "npm run test:nginx:mocha && npm run test:nginx:playwright",
     "test:nginx:mocha": "NODE_TLS_REJECT_UNAUTHORIZED=0 mocha ./nginx/src/mocha",
     "test:nginx:playwright": "NODE_TLS_REJECT_UNAUTHORIZED=0 playwright test",
-    "test": "npm run lint && npm run test:github-actions && npm run test:nginx"
+    "test:nginx-chunked-stream-error-passthrough": "./nginx/test-nginx-chunked-stream-error-passthrough.sh",
+    "test": "npm run lint && npm run test:github-actions && npm run test:nginx && npm run test:test-nginx-chunked-stream-error-passthrough"
   },
   "dependencies": {
     "@playwright/test": "^1.58.2",


### PR DESCRIPTION
Closes #1736

#### What has been done to verify that this works as intended?

watched CI not explode, plus [a test](https://github.com/getodk/central/pull/1737/changes#diff-fdf0396ee2376b0619bd9e8a66d186b1d20db1b887b9d200386ab58f5926f326) that fails in when nginx <-> backend is HTTP/1.0 .

#### Why is this the best possible solution? Were any other approaches considered?

See #1736 for background.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

N/A

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

N/A

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
