### PR TITLE
fix #1728 && fix sh compat

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
     build:
       context: .
       args:
-        DB_SSL: ${DB_SSL}  # So that we can error out at build time if this is defined with a value of "true" (no longer supported from 2026.1).
+        DB_SSL: ${DB_SSL:-}  # So that we can error out at build time if this is defined with a value of "true" (no longer supported from 2026.1).
       dockerfile: service.dockerfile
     depends_on:
       - secrets

--- a/service.dockerfile
+++ b/service.dockerfile
@@ -15,9 +15,8 @@ RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(grep -oP 'VERSION_CODEN
     && curl https://www.postgresql.org/media/keys/ACCC4CF8.asc \
       | gpg --dearmor > /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg
 
-
 ARG DB_SSL
-RUN [[ -v DB_SSL ]] && (echo '\n\n\n\n\nYou have the "DB_SSL" variable defined (in your .env file, probably).\nThis variable is no longer supported from Central 2026.1 onwards.\nThere is a new way of configuring SSL for your database, please see:\n\nhttps://docs.getodk.org/central-install-digital-ocean/#using-a-custom-database-server\n\nPlease refer to the Central 2026.1.0 release notes for more information on this change.\n\n\n\n\n'; exit 13) || true
+RUN [ -z "${DB_SSL}" ] || (/bin/echo -e '\n\n\n\n\nYou have the DB_SSL variable defined (in your .env file, probably).\nThis variable is no longer supported from Central 2026.1 onwards.\nThere is a new way of configuring SSL for your database, please see:\n\nhttps://docs.getodk.org/central-install-digital-ocean/#using-a-custom-database-server\n\nPlease refer to the Central 2026.1.0 release notes for more information on this change.\n\n\n\n\n'; exit 13)
 
 FROM node:${node_version}-slim AS intermediate
 RUN apt-get update \


### PR DESCRIPTION
Closes #1728

Also fixes `sh` compatibility.

#### What has been done to verify that this works as intended?

Manual testing, checking whether `docker compose build` displays the desired behaviour in presence and absence of a DB_SSL .env var (of nonzero length).

#### Why is this the best possible solution? Were any other approaches considered?

N/A

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

N/A

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

N/A

#### Before submitting this PR, please make sure you have:

- [X] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [X] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
