### PR TITLE
lint: reject .only in tests

### DIFF
--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -9,9 +9,13 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 'latest',
   },
+  plugins: [
+    'no-only-tests',
+  ],
   rules: {
     'comma-dangle': [ 'error', 'always-multiline' ],
     'eol-last': 'error',
+    'no-only-tests/no-only-tests': process.env.CI ? 'error' : 'off',
     'no-tabs': 'error',
     'no-trailing-spaces': 'error',
     'no-undef-init': 'error',

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -9,11 +9,9 @@
         "chai": "^5.2.0",
         "deep-equal-in-any-order": "^2.1.0",
         "eslint": "^9.28.0",
+        "eslint-plugin-no-only-tests": "^3.3.0",
         "mocha": "^11.7.5",
         "yaml": "^2.8.2"
-      },
-      "devDependencies": {
-        "eslint-plugin-no-only-tests": "^3.3.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -671,7 +669,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.3.0.tgz",
       "integrity": "sha512-brcKcxGnISN2CcVhXJ/kEQlNa0MEfGRtwKtWA16SkqXHKitaKIMrfemJKLKX1YqDU5C/5JY3PvZXd5jEW04e0Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=5.0.0"

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -11,6 +11,9 @@
         "eslint": "^9.28.0",
         "mocha": "^11.7.5",
         "yaml": "^2.8.2"
+      },
+      "devDependencies": {
+        "eslint-plugin-no-only-tests": "^3.3.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -662,6 +665,16 @@
         "jiti": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-no-only-tests": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.3.0.tgz",
+      "integrity": "sha512-brcKcxGnISN2CcVhXJ/kEQlNa0MEfGRtwKtWA16SkqXHKitaKIMrfemJKLKX1YqDU5C/5JY3PvZXd5jEW04e0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=5.0.0"
       }
     },
     "node_modules/eslint-scope": {

--- a/test/package.json
+++ b/test/package.json
@@ -15,5 +15,8 @@
   },
   "volta": {
     "node": "24.14.1"
+  },
+  "devDependencies": {
+    "eslint-plugin-no-only-tests": "^3.3.0"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -10,13 +10,11 @@
     "chai": "^5.2.0",
     "deep-equal-in-any-order": "^2.1.0",
     "eslint": "^9.28.0",
+    "eslint-plugin-no-only-tests": "^3.3.0",
     "mocha": "^11.7.5",
     "yaml": "^2.8.2"
   },
   "volta": {
     "node": "24.14.1"
-  },
-  "devDependencies": {
-    "eslint-plugin-no-only-tests": "^3.3.0"
   }
 }


### PR DESCRIPTION
#### What has been done to verify that this works as intended?

Tested locally and in CI with `.only` added to a test.

#### Why is this the best possible solution? Were any other approaches considered?

There are various plugins that offer this.  The particular plugin chosen here is also used in `odk-central-backend`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
