### PR TITLE
Install playwright in nginx subdirectory

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
     - run: cd test/nginx && npm run test:nginx:mocha
     - run: cd test/nginx && ./lint-config.sh
 
-    - run: npx playwright install --with-deps chromium
+    - run: cd test/nginx && npx playwright install --with-deps chromium
     - run: cd test/nginx && npm run test:nginx:playwright
 
     - if: always()


### PR DESCRIPTION
I believe the nginx tests on `next` are failing because playwright is installed in the wrong place.

#### What has been done to verify that this works as intended?
CI on this branch.

#### Why is this the best possible solution? Were any other approaches considered?
It's the only explanation I can think of.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
CI-only change, no user-facing risk.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
