### PR TITLE
ci/playwright: install fewer chromium variants

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
     - run: cd test/nginx && npm run test:nginx:mocha
     - run: cd test/nginx && ./lint-config.sh
 
-    - run: cd test/nginx && npx playwright install --with-deps chromium
+    - run: cd test/nginx && npx playwright install --with-deps chromium-headless-shell
     - run: cd test/nginx && npm run test:nginx:playwright
 
     - if: always()


### PR DESCRIPTION
The previous command `playwright install chromium` installs:

* `chromium`
* `chromium_headless_shell`

This change should ensure faster test runs by only installing the playwright browser used in tests: `chromium_headless_shell`.

Noted while investigating https://github.com/getodk/central/pull/1748

#### What has been done to verify that this works as intended?

- [x] checked CI still passes
- [x] checked installed browsers in https://github.com/getodk/central/actions/runs/23885864988/job/69648471961

#### Why is this the best possible solution? Were any other approaches considered?

Saves 170 MB download, making builds faster.  OTOH it might be more annoying to maintain if `chromium-headless-shell` gets dropped or merged into `chromium` or something.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect on users, and no risks - this is a CI change.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
