### PR TITLE
reimplant PG* env vars for cronjobs, fixes #1747

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
     - run: docker compose version
     - uses: actions/checkout@v5
     - run: ./test/check-submodules.sh
+    - run: ./test/test-with-pgenvblock.sh
     - run: sudo apt-get install shellcheck
     - run: ./test/check-scripts.sh
     - run: ./test/check-for-large-files.sh

--- a/files/service/crontab
+++ b/files/service/crontab
@@ -1,5 +1,5 @@
-0 5 * * * root /usr/odk/upload-blobs.sh
-0 4 * * * root /usr/odk/purge.sh
-0 3 * * * root /usr/odk/run-analytics.sh
-0 2 * * * root /usr/odk/process-backlog.sh
-0 1 * * 0 root /usr/odk/reap-sessions.sh
+0 5 * * * root /usr/bin/with-pgenvblock.pl /dev/shm/docker-envblock /usr/odk/upload-blobs.sh
+0 4 * * * root /usr/bin/with-pgenvblock.pl /dev/shm/docker-envblock /usr/odk/purge.sh
+0 3 * * * root /usr/bin/with-pgenvblock.pl /dev/shm/docker-envblock /usr/odk/run-analytics.sh
+0 2 * * * root /usr/bin/with-pgenvblock.pl /dev/shm/docker-envblock /usr/odk/process-backlog.sh
+0 1 * * 0 root /usr/bin/with-pgenvblock.pl /dev/shm/docker-envblock /usr/odk/reap-sessions.sh

--- a/files/service/scripts/start-odk.sh
+++ b/files/service/scripts/start-odk.sh
@@ -2,6 +2,13 @@
 set -o pipefail
 shopt -s inherit_errexit
 
+# Serialize (as a raw env block) the environment set up by docker, for later
+# availability to processes running with a reset environment (such as cronjobs).
+# See https://github.com/getodk/central/issues/1747 .
+# See `man 5 proc_pid_environ` .
+cp --preserve=mode,ownership /proc/self/environ /dev/shm/docker-envblock
+
+
 echo "generating local service configuration.."
 
 ENKETO_API_KEY=$(cat /etc/secrets/enketo-api-key) \

--- a/files/service/with-pgenvblock.pl
+++ b/files/service/with-pgenvblock.pl
@@ -1,0 +1,24 @@
+#!/usr/bin/env perl
+
+use warnings;
+use strict;
+
+
+die "Not enough arguments.\nUsage: with-pgenvblock.pl /path/to/envblock program [program-arg, …]\n" if @ARGV < 2;
+
+my $envblockfile = $ARGV[0];
+
+open my $fh, '<:raw', $envblockfile
+    or die "Cannot open '" . $envblockfile . "': $!";
+my $content = <$fh>;
+close $fh;
+
+my @entries = split /\x00/, $content;
+
+for my $entry (@entries) {
+    if ($entry =~ /\A(?<varname>PG[^=]+)=(?<varvalue>.*)\Z/m) {
+        $ENV{$+{varname}} = $+{varvalue};
+    }
+}
+
+exec @ARGV[1..$#ARGV];

--- a/service.dockerfile
+++ b/service.dockerfile
@@ -63,6 +63,7 @@ COPY files/service/scripts/ ./
 COPY files/service/config.json.template /usr/share/odk/
 COPY files/service/crontab /etc/cron.d/odk
 COPY files/service/odk-cmd /usr/bin/
+COPY files/service/with-pgenvblock.pl /usr/bin/
 
 COPY --from=intermediate /tmp/sentry-versions/ ./sentry-versions
 

--- a/test/test-with-pgenvblock.sh
+++ b/test/test-with-pgenvblock.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -eu
+set -o pipefail
+shopt -s inherit_errexit
+
+printf >&2 "Checking whether with-pgenvblock.pl works… "
+# for the skeptical reader, on the below:
+# note that the environment setting (with `export`) runs in a subshell, and as such doesn't touch our own environment,
+# and as such thus also not the environment with-pgenvblock.pl's is launched with; and thus the PGBLA environment variable
+# that the `env` invocation sees comes from `with-pgenvblock.pl`'s reading of the env block file and nowhere else.
+files/service/with-pgenvblock.pl <(export PGBLA=hurray; cat /proc/self/environ) env | grep --quiet '^PGBLA=hurray$' || (printf >&2 "No, it doesn't\n"; false) && printf >&2 "Yes\n"


### PR DESCRIPTION
Closes #1747

#### What has been done to verify that this works as intended?

- Automated test: Added a basic test (of the env setting utility itself).

- Ad-hoc manual test: Created a cronjob that dumps its env to a file, ran the service container with this here code, saw the file appear with PG* variables inside, rejoiced

But there's no _automated_ end-to-end-test (yet?) asserting that the cronjobs will now
work again and will keep working (specifically, where they failed previously because of absent `PG*` env vars).

#### Why is this the best possible solution? Were any other approaches considered?

Discussed on Slack and in a meet.

I opted for using the env representation from `/proc`, as it's null-separated, which makes parsing easier!
Why? Because IIUC the ASCII null is the only char guaranteed to not appear in varnames or varvalues. From `man 7 environ`:

> By convention, the strings in environ have the form "name=value".  The name is case-sensitive and may not contain the character "=".  The value can be  anything  that can be represented as a string.  The name and the value may not contain an embedded null byte ('\0'), since this is assumed to terminate the string.

Thus IIUC `/proc/$PID/environ` is pretty close to, or _is in fact_, the canonical representation of an env. So that's what we'll use then, rather than some intermediary format (such as the output of the `env` utility).

And I opted against writing the vars out again in some intermediary text-based representation (eg newline-separated `EXPORT bla="boop beep"` lines) fit for reading through `source`, as then everything will need to be quoted and escaped, and even if you get that right, it'd be hard to review and test.
I think the winning move is to just not to use an intermediary format :laughing:
And thus there is a wrapper\* script for the cronjobs, and the cronjobs themselves don't have to do anything (such as first sourcing some intermediary shell-format assignment list).

\*) not strictly a "wrapper" because it uses `exec` and thus self-dissolves.

Implementation notes:
- I chose Perl because it's there and it can handle this stuff better than for-each-line-of-text style tools such as awk or sed.
- I use its `exec` so that it self-dissolves into the launched program, file descriptors get inherited so the cronjob's std{out,err} and exitcode are what cron "sees", we're not wrapping or layering
- The regex for extracting the env var KV pairs hardcodes the `PG` prefix, so only `PG*` variables get reinjected in the cronjobs. This is because in the meeting @matthew-white argued convincingly against propagating *all* env vars to the cronjobs *right now*, not because they shouldn't be (in fact, streamlining the execution environments of the cronjobs and the `node` server process makes absolute sense), but more because they've been operating without them (for better or worse) up until now and we don't want to have to check whether they won't be upset by them so close to the release.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

N/A

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

N/A

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
