### PR TITLE
feat: Support self-hosted Sentry via DSN

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -38,9 +38,7 @@ HTTPS_PORT=443
 # OIDC_CLIENT_SECRET=
 
 # Optional: configure error reporting
-# SENTRY_ORG_SUBDOMAIN=
-# SENTRY_KEY=
-# SENTRY_PROJECT=
+# SENTRY_DSN=
 # SENTRY_TRACE_RATE=
 
 # Optional: configure S3-compatible storage for binary files

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -200,7 +200,7 @@ server {
   }
 
   location /csp-report {
-    proxy_pass https://${SENTRY_ORG_SUBDOMAIN}.ingest.sentry.io/api/${SENTRY_PROJECT}/security/?sentry_key=${SENTRY_KEY};
+    proxy_pass ${SENTRY_CSP_ENDPOINT};
     proxy_ssl_server_name on;
   }
 }

--- a/files/nginx/setup-odk.sh
+++ b/files/nginx/setup-odk.sh
@@ -44,10 +44,34 @@ echo "writing fresh nginx templates..."
   < /usr/share/odk/nginx/redirector.conf \
   > /etc/nginx/conf.d/redirector.conf
 
+if [ -n "${SENTRY_DSN:-}" ]; then
+  # SENTRY_DSN is in format {PROTOCOL}://{PUBLIC_KEY}@{HOST}/{PATH}{PROJECT_ID}
+  # We need to build {PROTOCOL}://{HOST}/{PATH}/api/{PROJECT_ID}/security/?sentry_key={PUBLIC_KEY}
+  # for the CSP reporting endpoint.
+  DSN_NO_PROTO=${SENTRY_DSN#*://}
+  KEY=${DSN_NO_PROTO%%@*}
+  REST=${DSN_NO_PROTO#*@}
+  PROJECT=${REST##*/}
+  HOST_PATH=${REST%/*}
+  PROTO=${SENTRY_DSN%%:*}
+  export SENTRY_CSP_ENDPOINT="${PROTO}://${HOST_PATH}/api/${PROJECT}/security/?sentry_key=${KEY}"
+else
+  # Sentry is not configured. We will replace the csp-report location block
+  # after envsub.awk has run. We set a dummy value here to avoid an empty
+  # proxy_pass directive, which would cause an error.
+  export SENTRY_CSP_ENDPOINT="http://localhost"
+fi
+
 CERT_DOMAIN=$( [ "$SSL_TYPE" = "customssl" ] && echo "local" || echo "$DOMAIN") \
 /scripts/envsub.awk \
   < /usr/share/odk/nginx/odk.conf.template \
   > /etc/nginx/conf.d/odk.conf
+
+if [ -z "${SENTRY_DSN:-}" ]; then
+  # Sentry is not configured. Replace the csp-report location block
+  # with one that simply returns 204 No Content.
+  perl -i -0777 -pe 's/location \/csp-report \{.*?\}/location \/csp-report { return 204; }/s' /etc/nginx/conf.d/odk.conf
+fi
 
 if [ "$SSL_TYPE" = "letsencrypt" ]; then
   echo "starting nginx for letsencrypt..."

--- a/files/service/config.json.template
+++ b/files/service/config.json.template
@@ -42,9 +42,7 @@
     },
     "external": {
       "sentry": {
-        "orgSubdomain": "${SENTRY_ORG_SUBDOMAIN}",
-        "key": "${SENTRY_KEY}",
-        "project": "${SENTRY_PROJECT}",
+        "dsn": "${SENTRY_DSN}",
         "traceRate": "${SENTRY_TRACE_RATE}"
       },
       "s3blobStore": {


### PR DESCRIPTION
## Summary

This change updates the Sentry configuration to use a DSN (Data Source Name) instead of separate fields for organization, key, and project. This allows users to configure Central with self-hosted Sentry instances. The Nginx configuration has been updated to parse the DSN to construct the CSP reporting endpoint, and the setup is now more robust when Sentry is not configured.

## Changes

- **.env.template**: Replaced SENTRY_ORG_SUBDOMAIN, SENTRY_KEY, and SENTRY_PROJECT with SENTRY_DSN to support self-hosted Sentry instances, which is the standard way to configure Sentry clients.
- **files/nginx/odk.conf.template**: Updated the `/csp-report` location block to use a single `SENTRY_CSP_ENDPOINT` variable. This variable will be constructed from the `SENTRY_DSN` in the `setup-odk.sh` script, allowing for flexible Sentry endpoint configuration.
- **files/nginx/setup-odk.sh**: Added logic to parse the SENTRY_DSN environment variable to construct the Sentry CSP endpoint URL. Also added a fallback for when SENTRY_DSN is not set, which makes the Nginx configuration robust by replacing the Sentry proxy block with a simple `return 204` to gracefully handle CSP reports.
- **files/service/config.json.template**: Updated the backend service configuration to accept a Sentry `dsn` instead of separate `orgSubdomain`, `key`, and `project` fields. This aligns with the move to a single DSN for Sentry configuration.

## Related Issue

Closes #1489

