### PR TITLE
csp: allow central's outdated-version page

### DIFF
--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -81,10 +81,10 @@ map $arg_st $redirect_single_prefix {
 map $request_uri $central_frontend_csp {
   # Web Forms CSP for /f/... and /projects/.../forms/... routes
   ~^/(?:f/[^/]+(?:/.*)?|projects/\d+/forms/[^/]+/(?:(?:draft/)?(?:preview|submissions/new(?:/offline)?)|submissions/[^/]+/edit)(?:/)?)(?:\?.*)?$
-    "default-src 'report-sample' 'none'; connect-src 'self' https:; font-src 'self' data:; frame-src 'self'; img-src blob: data: https:; manifest-src 'none'; media-src 'none'; object-src 'none'; script-src 'report-sample' 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; worker-src 'report-sample' blob:; report-uri /csp-report";
+    "default-src 'report-sample' 'none'; connect-src 'self' https:; font-src 'self' data:; frame-src 'self' https://getodk.github.io/central/; img-src blob: data: https:; manifest-src 'none'; media-src 'none'; object-src 'none'; script-src 'report-sample' 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; worker-src 'report-sample' blob:; report-uri /csp-report";
 
   default
-    "default-src 'report-sample' 'none'; connect-src 'self' https://translate.google.com https://translate.googleapis.com; font-src 'self'; frame-src 'self' https://getodk.github.io/central/news.html; img-src data: https:; manifest-src 'none'; media-src 'none'; object-src 'none'; script-src 'report-sample' 'self'; style-src 'report-sample' 'self'; style-src-attr 'unsafe-inline'; worker-src 'report-sample' blob:; report-uri /csp-report";
+    "default-src 'report-sample' 'none'; connect-src 'self' https://translate.google.com https://translate.googleapis.com; font-src 'self'; frame-src 'self' https://getodk.github.io/central/; img-src data: https:; manifest-src 'none'; media-src 'none'; object-src 'none'; script-src 'report-sample' 'self'; style-src 'report-sample' 'self'; style-src-attr 'unsafe-inline'; worker-src 'report-sample' blob:; report-uri /csp-report";
 }
 
 server {

--- a/test/nginx/src/mocha/nginx.spec.js
+++ b/test/nginx/src/mocha/nginx.spec.js
@@ -14,7 +14,7 @@ const self = `'self'`;
 const unsafeInline = `'unsafe-inline'`;
 const wasmUnsafeEval = `'wasm-unsafe-eval'`;
 
-// Central has notifications shared from GitHub Pages including:
+// Central has notifications defined in https://github.com/getodk/central/tree/master/docs, and served from GitHub Pages.  These include:
 //
 // * https://getodk.github.io/central/news.html
 // * https://getodk.github.io/central/outdated-version.html

--- a/test/nginx/src/mocha/nginx.spec.js
+++ b/test/nginx/src/mocha/nginx.spec.js
@@ -14,6 +14,12 @@ const self = `'self'`;
 const unsafeInline = `'unsafe-inline'`;
 const wasmUnsafeEval = `'wasm-unsafe-eval'`;
 
+// Central has notifications shared from GitHub Pages including:
+//
+// * https://getodk.github.io/central/news.html
+// * https://getodk.github.io/central/outdated-version.html
+const centralNotifications = 'https://getodk.github.io/central/';
+
 const asArray = val => {
   if (val == null) return [];
   if (Array.isArray(val)) return val;
@@ -65,7 +71,7 @@ const contentSecurityPolicies = {
       'font-src':       self,
       'frame-src':      [
         self,
-        'https://getodk.github.io/central/news.html',
+        centralNotifications,
       ],
       'img-src': [
         'data:',
@@ -173,7 +179,10 @@ const contentSecurityPolicies = {
         self,
         'data:',
       ],
-      'frame-src': self, // web-forms pages also host /enketo-passthrough/ URLs via iframes
+      'frame-src': [
+        self, // web-forms pages also host /enketo-passthrough/ URLs via iframes
+        centralNotifications,
+      ],
       'img-src': [
         'blob:',
         'data:',

--- a/test/nginx/src/playwright/csp.spec.js
+++ b/test/nginx/src/playwright/csp.spec.js
@@ -36,7 +36,7 @@ test('catches style-src-elem violation samples', async ({ page }) => {
           'referrer': '',
           'violated-directive': 'style-src-elem',
           'effective-directive': 'style-src-elem',
-          'original-policy': `default-src 'report-sample' 'none'; connect-src 'self' https://translate.google.com https://translate.googleapis.com; font-src 'self'; frame-src 'self' https://getodk.github.io/central/news.html; img-src data: https:; manifest-src 'none'; media-src 'none'; object-src 'none'; script-src 'report-sample' 'self'; style-src 'report-sample' 'self'; style-src-attr 'unsafe-inline'; worker-src 'report-sample' blob:; report-uri /csp-report`,
+          'original-policy': `default-src 'report-sample' 'none'; connect-src 'self' https://translate.google.com https://translate.googleapis.com; font-src 'self'; frame-src 'self' https://getodk.github.io/central/; img-src data: https:; manifest-src 'none'; media-src 'none'; object-src 'none'; script-src 'report-sample' 'self'; style-src 'report-sample' 'self'; style-src-attr 'unsafe-inline'; worker-src 'report-sample' blob:; report-uri /csp-report`,
           'disposition': 'report',
           'blocked-uri': 'inline',
           'line-number': 5,


### PR DESCRIPTION
Closes #1777

#### What has been done to verify that this works as intended?

CI.

#### Why is this the best possible solution? Were any other approaches considered?

Could be more specific, and list each specific page.  Adds header size overhead, and annoying to maintain as it might be forgotten if new content is added in https://github.com/getodk/central/tree/master/docs.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
