### PR TITLE
test/nginx: check mime types

### DIFF
--- a/test/nginx/src/mocha/nginx.spec.js
+++ b/test/nginx/src/mocha/nginx.spec.js
@@ -441,10 +441,15 @@ function standardTestSuite({ fetchHttp, fetchHttp6, apiFetch, apiFetch6, forward
   });
 
   [
-    [ '/index.html',  /<div id="app"><\/div>/ ],
-    [ '/version.txt', /^versions:/ ],
-    [ '/favicon.ico', /^\n$/ ],
-  ].forEach(([ path, expectedContent ]) => {
+    [ '/index.html',                 'text/html', /<div id="app"><\/div>/ ],
+    [ '/version.txt',                'text/plain', /^versions:/ ],
+    [ '/android-chrome-192x192.png', 'image/png',    /^\n$/ ],
+    [ '/android-chrome-512x512.png', 'image/png',    /^\n$/ ],
+    [ '/apple-touch-icon.png',       'image/png',    /^\n$/ ],
+    [ '/favicon.ico',                'image/x-icon', /^\n$/ ],
+    [ '/favicon-16x16.png',          'image/png',    /^\n$/ ],
+    [ '/favicon-32x32.png',          'image/png',    /^\n$/ ],
+  ].forEach(([ path, expectedContentType, expectedContent ]) => {
     it(`${path} file should serve expected content`, async () => {
       // when
       const res = await apiFetch(path);
@@ -452,6 +457,7 @@ function standardTestSuite({ fetchHttp, fetchHttp6, apiFetch, apiFetch6, forward
       // then
       assert.equal(res.status, 200);
       assert.match(await res.text(), expectedContent);
+      assert.equal(res.headers.get('Content-Type'), expectedContentType);
       assertSecurityHeaders(res, { csp:'central-frontend' });
     });
   });

--- a/test/nginx/src/mocha/nginx.spec.js
+++ b/test/nginx/src/mocha/nginx.spec.js
@@ -441,14 +441,9 @@ function standardTestSuite({ fetchHttp, fetchHttp6, apiFetch, apiFetch6, forward
   });
 
   [
-    [ '/index.html',                 'text/html', /<div id="app"><\/div>/ ],
-    [ '/version.txt',                'text/plain', /^versions:/ ],
-    [ '/android-chrome-192x192.png', 'image/png',    /^\n$/ ],
-    [ '/android-chrome-512x512.png', 'image/png',    /^\n$/ ],
-    [ '/apple-touch-icon.png',       'image/png',    /^\n$/ ],
-    [ '/favicon.ico',                'image/x-icon', /^\n$/ ],
-    [ '/favicon-16x16.png',          'image/png',    /^\n$/ ],
-    [ '/favicon-32x32.png',          'image/png',    /^\n$/ ],
+    [ '/index.html',  'text/html',    /<div id="app"><\/div>/ ],
+    [ '/version.txt', 'text/plain',   /^versions:/ ],
+    [ '/favicon.ico', 'image/x-icon', /^\n$/ ],
   ].forEach(([ path, expectedContentType, expectedContent ]) => {
     it(`${path} file should serve expected content`, async () => {
       // when


### PR DESCRIPTION
Assert that `Content-Type` headers are set as expected on some common file types.

#### What has been done to verify that this works as intended?

Added new tests.

#### Why is this the best possible solution? Were any other approaches considered?

Work on future favicon filetypes may require fiddling with settings which could disrupt mime types.  Adding checks that existing types don't change in future seemed helpful, as adding a new type is not as simple as might be expected (https://github.com/getodk/central/pull/1722).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect - just test changes.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
