### PR TITLE
csp: allow web application manifest

### DIFF
--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -91,10 +91,10 @@ map $arg_st $redirect_single_prefix {
 map $request_uri $central_frontend_csp {
   # Web Forms CSP for /f/... and /projects/.../forms/... routes
   ~^/(?:f/[^/]+(?:/.*)?|projects/\d+/forms/[^/]+/(?:(?:draft/)?(?:preview|submissions/new(?:/offline)?)|submissions/[^/]+/edit)(?:/)?)(?:\?.*)?$
-    "default-src 'report-sample' 'none'; connect-src 'self' https:; font-src 'self' data:; frame-src 'self' https://getodk.github.io/central/; img-src blob: data: https:; manifest-src 'none'; media-src 'none'; object-src 'none'; script-src 'report-sample' 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; worker-src 'report-sample' blob:; report-uri /csp-report";
+    "default-src 'report-sample' 'none'; connect-src 'self' https:; font-src 'self' data:; frame-src 'self' https://getodk.github.io/central/; img-src blob: data: https:; manifest-src 'self'; media-src 'none'; object-src 'none'; script-src 'report-sample' 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; worker-src 'report-sample' blob:; report-uri /csp-report";
 
   default
-    "default-src 'report-sample' 'none'; connect-src 'self' https://translate.google.com https://translate.googleapis.com; font-src 'self'; frame-src 'self' https://getodk.github.io/central/; img-src data: https:; manifest-src 'none'; media-src 'none'; object-src 'none'; script-src 'report-sample' 'self'; style-src 'report-sample' 'self'; style-src-attr 'unsafe-inline'; worker-src 'report-sample' blob:; report-uri /csp-report";
+    "default-src 'report-sample' 'none'; connect-src 'self' https://translate.google.com https://translate.googleapis.com; font-src 'self'; frame-src 'self' https://getodk.github.io/central/; img-src data: https:; manifest-src 'self'; media-src 'none'; object-src 'none'; script-src 'report-sample' 'self'; style-src 'report-sample' 'self'; style-src-attr 'unsafe-inline'; worker-src 'report-sample' blob:; report-uri /csp-report";
 }
 
 server {

--- a/test/nginx/src/mocha/nginx.spec.js
+++ b/test/nginx/src/mocha/nginx.spec.js
@@ -77,7 +77,7 @@ const contentSecurityPolicies = {
         'data:',
         'https:',
       ],
-      'manifest-src':   none,
+      'manifest-src':   self,
       'media-src':      none,
       'object-src':     none,
       'script-src': [
@@ -188,7 +188,7 @@ const contentSecurityPolicies = {
         'data:',
         'https:',
       ],
-      'manifest-src': none,
+      'manifest-src': self,
       'media-src': none,
       'object-src': none,
       'script-src': [

--- a/test/nginx/src/playwright/csp.spec.js
+++ b/test/nginx/src/playwright/csp.spec.js
@@ -36,7 +36,7 @@ test('catches style-src-elem violation samples', async ({ page }) => {
           'referrer': '',
           'violated-directive': 'style-src-elem',
           'effective-directive': 'style-src-elem',
-          'original-policy': `default-src 'report-sample' 'none'; connect-src 'self' https://translate.google.com https://translate.googleapis.com; font-src 'self'; frame-src 'self' https://getodk.github.io/central/; img-src data: https:; manifest-src 'none'; media-src 'none'; object-src 'none'; script-src 'report-sample' 'self'; style-src 'report-sample' 'self'; style-src-attr 'unsafe-inline'; worker-src 'report-sample' blob:; report-uri /csp-report`,
+          'original-policy': `default-src 'report-sample' 'none'; connect-src 'self' https://translate.google.com https://translate.googleapis.com; font-src 'self'; frame-src 'self' https://getodk.github.io/central/; img-src data: https:; manifest-src 'self'; media-src 'none'; object-src 'none'; script-src 'report-sample' 'self'; style-src 'report-sample' 'self'; style-src-attr 'unsafe-inline'; worker-src 'report-sample' blob:; report-uri /csp-report`,
           'disposition': 'report',
           'blocked-uri': 'inline',
           'line-number': 5,


### PR DESCRIPTION
A web application manifest was introduced to `odk-central-frontend` alongside modern favicons in https://github.com/getodk/central-frontend/pull/1509.

See:

* https://getodk.sentry.io/issues/7407189152/
* https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Manifest
* https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/manifest-src


#### What has been done to verify that this works as intended?

New tests.

#### Why is this the best possible solution? Were any other approaches considered?

* con: maybe an issue if an attacker can inject a manifest to be served from `'self'`
* pro: `manifest-src` is required, as otherwise falls back to `default-src`

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
