### PR TITLE
ci/test-nginx: show mock-sentry logs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,8 @@ jobs:
       run: cd test/nginx && docker compose -f nginx.test.docker-compose.yml logs --no-log-prefix service
     - if: always()
       run: cd test/nginx && docker compose -f nginx.test.docker-compose.yml logs --no-log-prefix enketo
+    - if: always()
+      run: cd test/nginx && docker compose -f nginx.test.docker-compose.yml logs --no-log-prefix sentry-mock
   test-secrets:
     timeout-minutes: 2
     runs-on: ubuntu-latest


### PR DESCRIPTION
Helpful for debugging issues.

#### What has been done to verify that this works as intended?

Run CI and checked the relevant logs: https://github.com/getodk/central/actions/runs/24507262138/job/71628862703?pr=1816

#### Why is this the best possible solution? Were any other approaches considered?

In line with showing logs of other build jobs.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect - just CI.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No - just a CI change.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
