### PR TITLE
test/nginx/csp: rename backend-strict policy

### DIFF
--- a/test/nginx/src/mocha/nginx.spec.js
+++ b/test/nginx/src/mocha/nginx.spec.js
@@ -41,6 +41,22 @@ const allowGoogleTranslate = ({ 'connect-src':connectSrc, 'img-src':imgSrc, ...o
 };
 
 const contentSecurityPolicies = {
+  'backend-strict': {
+    block: {
+      'default-src':     'NOTE:FROM-BACKEND:block',
+      'form-action':     'NOTE:FROM-BACKEND:block',
+      'frame-ancestors': 'NOTE:FROM-BACKEND:block',
+    },
+    reportOnly: {
+      'default-src': [
+        reportSample,
+        none,
+      ],
+      'form-action': none,
+      'frame-ancestors': none,
+      'report-uri':  '/csp-report',
+    },
+  },
   'backend-unmodified': {
     block: {
       'default-src':     'NOTE:FROM-BACKEND:block',
@@ -103,22 +119,6 @@ const contentSecurityPolicies = {
       ],
       'report-uri':     '/csp-report',
     }),
-  },
-  'disallow-all': {
-    block: {
-      'default-src':     'NOTE:FROM-BACKEND:block',
-      'form-action':     'NOTE:FROM-BACKEND:block',
-      'frame-ancestors': 'NOTE:FROM-BACKEND:block',
-    },
-    reportOnly: {
-      'default-src': [
-        reportSample,
-        none,
-      ],
-      'form-action': none,
-      'frame-ancestors': none,
-      'report-uri':  '/csp-report',
-    },
   },
   enketo: {
     block: {
@@ -652,7 +652,7 @@ function standardTestSuite({ fetchHttp, fetchHttp6, apiFetch, apiFetch6, forward
     // then
     assert.equal(res.status, 200);
     assert.equal(await res.text(), 'OK');
-    assertSecurityHeaders(res, { csp:'disallow-all' });
+    assertSecurityHeaders(res, { csp:'backend-strict' });
     // and
     await assertBackendReceived(
       { method:'GET', path:'/v1/some/central-backend/path' },
@@ -674,7 +674,7 @@ function standardTestSuite({ fetchHttp, fetchHttp6, apiFetch, apiFetch6, forward
     const res = await apiFetch('/v1/reflect-headers');
     // then
     assert.equal(res.status, 200);
-    assertSecurityHeaders(res, { csp:'disallow-all' });
+    assertSecurityHeaders(res, { csp:'backend-strict' });
 
     // when
     const body = await res.json();
@@ -692,7 +692,7 @@ function standardTestSuite({ fetchHttp, fetchHttp6, apiFetch, apiFetch6, forward
     // then
     assert.equal(res.status, 200);
     // and
-    assertSecurityHeaders(res, { csp:'disallow-all' });
+    assertSecurityHeaders(res, { csp:'backend-strict' });
 
     // when
     const body = await res.json();


### PR DESCRIPTION
Previously called `disallow-all`; rename to `backend-strict` to better reflect its usage rather than current implementation details.

Prep work for #1814

#### What has been done to verify that this works as intended?

CI.

#### Why is this the best possible solution? Were any other approaches considered?

* standardises alongside `backend-unmodified`
* prepares for future work
* communicates usage instead of current implementation details

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
