### PR TITLE
nginx/csp: allow favicons for backend requests

### DIFF
--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -183,7 +183,7 @@ server {
 
   location ~ ^/v\d {
     proxy_hide_header Content-Security-Policy-Report-Only;
-    add_header Content-Security-Policy-Report-Only "default-src 'report-sample' 'none'; form-action 'none'; frame-ancestors 'none'; report-uri /csp-report" always;
+    add_header Content-Security-Policy-Report-Only "default-src 'report-sample' 'none'; form-action 'none'; frame-ancestors 'none'; img-src http://${DOMAIN}/favicon.ico; report-uri /csp-report" always;
 
     include /usr/share/odk/nginx/common-headers.conf;
     include /usr/share/odk/nginx/backend.conf;

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -114,7 +114,7 @@ server {
 
   server_tokens off;
 
-  add_header Content-Security-Policy-Report-Only "default-src 'report-sample' 'none'; connect-src https://translate.google.com https://translate.googleapis.com; img-src https://{DOMAIN}/favicon.icon https://translate.google.com; report-uri /csp-report" always;
+  add_header Content-Security-Policy-Report-Only "default-src 'report-sample' 'none'; connect-src https://translate.google.com https://translate.googleapis.com; img-src https://${DOMAIN}/favicon.icon https://translate.google.com; report-uri /csp-report" always;
   include /usr/share/odk/nginx/common-headers.conf;
 
   client_max_body_size 100m;
@@ -193,7 +193,7 @@ server {
     root /usr/share/nginx/html;
     try_files /blank.html =404;
 
-    add_header Content-Security-Policy-Report-Only "default-src 'report-sample' 'none'; connect-src https://translate.google.com https://translate.googleapis.com; form-action 'none'; frame-ancestors 'self'; img-src https://{DOMAIN}/favicon.icon https://translate.google.com; report-uri /csp-report" always;
+    add_header Content-Security-Policy-Report-Only "default-src 'report-sample' 'none'; connect-src https://translate.google.com https://translate.googleapis.com; form-action 'none'; frame-ancestors 'self'; img-src https://${DOMAIN}/favicon.icon https://translate.google.com; report-uri /csp-report" always;
     include /usr/share/odk/nginx/common-headers.conf;
   }
   location = /blank.html {

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -114,7 +114,7 @@ server {
 
   server_tokens off;
 
-  add_header Content-Security-Policy-Report-Only "default-src 'report-sample' 'none'; connect-src https://translate.google.com https://translate.googleapis.com; https://translate.google.com; report-uri /csp-report" always;
+  add_header Content-Security-Policy-Report-Only "default-src 'report-sample' 'none'; connect-src https://translate.google.com https://translate.googleapis.com; img-src https://translate.google.com; report-uri /csp-report" always;
   include /usr/share/odk/nginx/common-headers.conf;
 
   client_max_body_size 100m;

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -114,7 +114,7 @@ server {
 
   server_tokens off;
 
-  add_header Content-Security-Policy-Report-Only "default-src 'report-sample' 'none'; connect-src https://translate.google.com https://translate.googleapis.com; img-src http://${DOMAIN}/favicon.ico https://translate.google.com; report-uri /csp-report" always;
+  add_header Content-Security-Policy-Report-Only "default-src 'report-sample' 'none'; connect-src https://translate.google.com https://translate.googleapis.com; https://translate.google.com; report-uri /csp-report" always;
   include /usr/share/odk/nginx/common-headers.conf;
 
   client_max_body_size 100m;

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -114,7 +114,7 @@ server {
 
   server_tokens off;
 
-  add_header Content-Security-Policy-Report-Only "default-src 'report-sample' 'none'; connect-src https://translate.google.com https://translate.googleapis.com; img-src http://${DOMAIN}/favicon.icon https://translate.google.com; report-uri /csp-report" always;
+  add_header Content-Security-Policy-Report-Only "default-src 'report-sample' 'none'; connect-src https://translate.google.com https://translate.googleapis.com; img-src http://${DOMAIN}/favicon.ico https://translate.google.com; report-uri /csp-report" always;
   include /usr/share/odk/nginx/common-headers.conf;
 
   client_max_body_size 100m;
@@ -193,7 +193,7 @@ server {
     root /usr/share/nginx/html;
     try_files /blank.html =404;
 
-    add_header Content-Security-Policy-Report-Only "default-src 'report-sample' 'none'; connect-src https://translate.google.com https://translate.googleapis.com; form-action 'none'; frame-ancestors 'self'; img-src http://${DOMAIN}/favicon.icon https://translate.google.com; report-uri /csp-report" always;
+    add_header Content-Security-Policy-Report-Only "default-src 'report-sample' 'none'; connect-src https://translate.google.com https://translate.googleapis.com; form-action 'none'; frame-ancestors 'self'; img-src http://${DOMAIN}/favicon.ico https://translate.google.com; report-uri /csp-report" always;
     include /usr/share/odk/nginx/common-headers.conf;
   }
   location = /blank.html {

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -114,7 +114,7 @@ server {
 
   server_tokens off;
 
-  add_header Content-Security-Policy-Report-Only "default-src 'report-sample' 'none'; connect-src https://translate.google.com https://translate.googleapis.com; img-src https://translate.google.com; report-uri /csp-report" always;
+  add_header Content-Security-Policy-Report-Only "default-src 'report-sample' 'none'; connect-src https://translate.google.com https://translate.googleapis.com; img-src https://{DOMAIN}/favicon.icon https://translate.google.com; report-uri /csp-report" always;
   include /usr/share/odk/nginx/common-headers.conf;
 
   client_max_body_size 100m;
@@ -193,7 +193,7 @@ server {
     root /usr/share/nginx/html;
     try_files /blank.html =404;
 
-    add_header Content-Security-Policy-Report-Only "default-src 'report-sample' 'none'; connect-src https://translate.google.com https://translate.googleapis.com; form-action 'none'; frame-ancestors 'self'; img-src 'self' https://translate.google.com; report-uri /csp-report" always;
+    add_header Content-Security-Policy-Report-Only "default-src 'report-sample' 'none'; connect-src https://translate.google.com https://translate.googleapis.com; form-action 'none'; frame-ancestors 'self'; img-src https://{DOMAIN}/favicon.icon https://translate.google.com; report-uri /csp-report" always;
     include /usr/share/odk/nginx/common-headers.conf;
   }
   location = /blank.html {

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -193,7 +193,7 @@ server {
     root /usr/share/nginx/html;
     try_files /blank.html =404;
 
-    add_header Content-Security-Policy-Report-Only "default-src 'report-sample' 'none'; connect-src https://translate.google.com https://translate.googleapis.com; form-action 'none'; frame-ancestors 'self'; img-src http://${DOMAIN}/favicon.ico https://translate.google.com; report-uri /csp-report" always;
+    add_header Content-Security-Policy-Report-Only "default-src 'report-sample' 'none'; connect-src https://translate.google.com https://translate.googleapis.com; form-action 'none'; frame-ancestors 'self'; img-src 'self' https://translate.google.com; report-uri /csp-report" always;
     include /usr/share/odk/nginx/common-headers.conf;
   }
   location = /blank.html {

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -114,7 +114,7 @@ server {
 
   server_tokens off;
 
-  add_header Content-Security-Policy-Report-Only "default-src 'report-sample' 'none'; connect-src https://translate.google.com https://translate.googleapis.com; img-src https://${DOMAIN}/favicon.icon https://translate.google.com; report-uri /csp-report" always;
+  add_header Content-Security-Policy-Report-Only "default-src 'report-sample' 'none'; connect-src https://translate.google.com https://translate.googleapis.com; img-src http://${DOMAIN}/favicon.icon https://translate.google.com; report-uri /csp-report" always;
   include /usr/share/odk/nginx/common-headers.conf;
 
   client_max_body_size 100m;
@@ -193,7 +193,7 @@ server {
     root /usr/share/nginx/html;
     try_files /blank.html =404;
 
-    add_header Content-Security-Policy-Report-Only "default-src 'report-sample' 'none'; connect-src https://translate.google.com https://translate.googleapis.com; form-action 'none'; frame-ancestors 'self'; img-src https://${DOMAIN}/favicon.icon https://translate.google.com; report-uri /csp-report" always;
+    add_header Content-Security-Policy-Report-Only "default-src 'report-sample' 'none'; connect-src https://translate.google.com https://translate.googleapis.com; form-action 'none'; frame-ancestors 'self'; img-src http://${DOMAIN}/favicon.icon https://translate.google.com; report-uri /csp-report" always;
     include /usr/share/odk/nginx/common-headers.conf;
   }
   location = /blank.html {

--- a/test/nginx/src/mocha/nginx.spec.js
+++ b/test/nginx/src/mocha/nginx.spec.js
@@ -54,7 +54,7 @@ const contentSecurityPolicies = {
       ],
       'form-action': none,
       'frame-ancestors': none,
-      'img-src': 'http://odk-nginx.example.test/favicon.ico', // http: scheme allows secure upgrade to https://
+      'img-src': 'http://odk-nginx.example.test/favicon.ico', // http: scheme permits secure upgrade to https://
       'report-uri':  '/csp-report',
     },
   },

--- a/test/nginx/src/mocha/nginx.spec.js
+++ b/test/nginx/src/mocha/nginx.spec.js
@@ -78,7 +78,7 @@ const contentSecurityPolicies = {
       ],
       'form-action': none,
       'frame-ancestors': self,
-      'img-src': 'http://odk-nginx.example.test/favicon.ico', // http: scheme allows secure upgrade to https://
+      'img-src': self, // allow favicon.ico
       'report-uri':  '/csp-report',
     }),
   },

--- a/test/nginx/src/mocha/nginx.spec.js
+++ b/test/nginx/src/mocha/nginx.spec.js
@@ -54,7 +54,7 @@ const contentSecurityPolicies = {
       ],
       'form-action': none,
       'frame-ancestors': none,
-      'img-src': 'http://odk-nginx.example.test/favicon.ico', // http:// allows secure upgrade to https://
+      'img-src': 'http://odk-nginx.example.test/favicon.ico', // http: scheme allows secure upgrade to https://
       'report-uri':  '/csp-report',
     },
   },
@@ -78,7 +78,7 @@ const contentSecurityPolicies = {
       ],
       'form-action': none,
       'frame-ancestors': self,
-      'img-src': 'http://odk-nginx.example.test/favicon.ico', // http:// allows secure upgrade to https://
+      'img-src': 'http://odk-nginx.example.test/favicon.ico', // http: scheme allows secure upgrade to https://
       'report-uri':  '/csp-report',
     }),
   },

--- a/test/nginx/src/mocha/nginx.spec.js
+++ b/test/nginx/src/mocha/nginx.spec.js
@@ -54,7 +54,7 @@ const contentSecurityPolicies = {
       ],
       'form-action': none,
       'frame-ancestors': none,
-      'img-src': 'https://domain-goes-here/favicon.ico',
+      'img-src': 'http://odk-nginx.example.test/favicon.ico', // http:// allows secure upgrade to https://
       'report-uri':  '/csp-report',
     },
   },
@@ -78,7 +78,7 @@ const contentSecurityPolicies = {
       ],
       'form-action': none,
       'frame-ancestors': self,
-      'img-src': 'https://domain-goes-here/favicon.ico',
+      'img-src': 'http://odk-nginx.example.test/favicon.ico', // http:// allows secure upgrade to https://
       'report-uri':  '/csp-report',
     }),
   },

--- a/test/nginx/src/mocha/nginx.spec.js
+++ b/test/nginx/src/mocha/nginx.spec.js
@@ -54,6 +54,7 @@ const contentSecurityPolicies = {
       ],
       'form-action': none,
       'frame-ancestors': none,
+      'img-src': 'https://domain-goes-here/favicon.ico',
       'report-uri':  '/csp-report',
     },
   },
@@ -77,7 +78,7 @@ const contentSecurityPolicies = {
       ],
       'form-action': none,
       'frame-ancestors': self,
-      'img-src': self, // allow favicon.ico
+      'img-src': 'https://domain-goes-here/favicon.ico',
       'report-uri':  '/csp-report',
     }),
   },


### PR DESCRIPTION
Closes #1851

#### What has been done to verify that this works as intended?

- [x] updated tests
- [x] tested in dev

#### Why is this the best possible solution? Were any other approaches considered?

* blanket policy for all backend responses
* ultimately should be moved to `Content-Security-Policy` instead of `Content-Security-Policy-Report-Only`, at which point care will need to be taken to ensure it's only set if no `Content-Security-Policy` is provided by `odk-central-backend`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

* No visible effect or risk of regression - currently report only.
* Should prevent `img-src` CSP violation reports being sent for `favicon.ico` requests, reducing users' bandwidth if they ever encountered this.
* Relaxation of current policy, so should not block previously-available content.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
