### PR TITLE
nginx/csp: blank.html: allow form-action 'self'

### DIFF
--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -193,7 +193,7 @@ server {
     root /usr/share/nginx/html;
     try_files /blank.html =404;
 
-    add_header Content-Security-Policy-Report-Only "default-src 'report-sample' 'none'; connect-src https://translate.google.com https://translate.googleapis.com; form-action 'none'; frame-ancestors 'self'; img-src 'self' https://translate.google.com; report-uri /csp-report" always;
+    add_header Content-Security-Policy-Report-Only "default-src 'report-sample' 'none'; connect-src https://translate.google.com https://translate.googleapis.com; form-action 'self'; frame-ancestors 'self'; img-src 'self' https://translate.google.com; report-uri /csp-report" always;
     include /usr/share/odk/nginx/common-headers.conf;
   }
   location = /blank.html {

--- a/test/nginx/src/mocha/nginx.spec.js
+++ b/test/nginx/src/mocha/nginx.spec.js
@@ -75,7 +75,7 @@ const contentSecurityPolicies = {
         reportSample,
         none,
       ],
-      'form-action': none,
+      'form-action': self, // allow decrypted zip downloads from central-frontend
       'frame-ancestors': self,
       'img-src': self, // allow favicon.ico
       'report-uri':  '/csp-report',


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/1856

#### What has been done to verify that this works as intended?

Updated tests.

#### Why is this the best possible solution? Were any other approaches considered?

Violations were reported to Sentry.  An alternative would be to make the decrypt downloading in central-frontend less arcane.  But that's not likely to be on the cards.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should prevent incorrect reports.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
