### PR TITLE
nginx/csp: enforce policy for central-backend

### DIFF
--- a/files/nginx/backend.conf
+++ b/files/nginx/backend.conf
@@ -1,8 +1,0 @@
-proxy_set_header X-Forwarded-Proto $scheme;
-proxy_pass http://service:8383;
-proxy_redirect off;
-
-# buffer requests, but not responses, so streaming out works.
-proxy_request_buffering on;
-proxy_buffering off;
-proxy_read_timeout 2m;

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -97,6 +97,11 @@ map $request_uri $central_frontend_csp {
     "default-src 'report-sample' 'none'; connect-src 'self' https://translate.google.com https://translate.googleapis.com; font-src 'self'; form-action 'self'; frame-ancestors 'none'; frame-src 'self' https://getodk.github.io/central/; img-src data: https:; manifest-src 'self'; media-src 'none'; object-src 'none'; script-src 'report-sample' 'self'; style-src 'report-sample' 'self'; style-src-attr 'unsafe-inline'; worker-src 'report-sample' blob:; report-uri /csp-report";
 }
 
+map $upstream_http_content_security_policy $central_backend_csp {
+  ""      "default-src 'report-sample' 'none'; form-action 'none'; frame-ancestors 'none'; report-uri /csp-report";
+  default $upstream_http_content_security_policy;
+}
+
 server {
   listen 443 ssl;
   http2 on;
@@ -176,17 +181,20 @@ server {
   }
   # End of Enketo Configuration.
 
-  location ~ ^/v\d+/oidc/callback$ {
-    include /usr/share/odk/nginx/common-headers.conf;
-    include /usr/share/odk/nginx/backend.conf;
-  }
-
   location ~ ^/v\d {
-    proxy_hide_header Content-Security-Policy-Report-Only;
-    add_header Content-Security-Policy-Report-Only "default-src 'report-sample' 'none'; form-action 'none'; frame-ancestors 'none'; report-uri /csp-report" always;
+    proxy_hide_header Content-Security-Policy;
+    add_header Content-Security-Policy $central_backend_csp always;
 
     include /usr/share/odk/nginx/common-headers.conf;
-    include /usr/share/odk/nginx/backend.conf;
+
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_pass http://service:8383;
+    proxy_redirect off;
+
+    # buffer requests, but not responses, so streaming out works.
+    proxy_request_buffering on;
+    proxy_buffering off;
+    proxy_read_timeout 2m;
   }
 
   location @blank.html {

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -98,6 +98,7 @@ map $request_uri $central_frontend_csp {
 }
 
 map $upstream_http_content_security_policy $central_backend_csp {
+  // pass through any Content-Security-Policy received from upstream services (central-backend, enketo)
   ""      "default-src 'report-sample' 'none'; form-action 'none'; frame-ancestors 'none'; report-uri /csp-report";
   default $upstream_http_content_security_policy;
 }

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -98,7 +98,7 @@ map $request_uri $central_frontend_csp {
 }
 
 map $upstream_http_content_security_policy $central_backend_csp {
-  // pass through any Content-Security-Policy received from upstream services (central-backend, enketo)
+  # pass through any Content-Security-Policy received from upstream services (central-backend, enketo)
   ""      "default-src 'report-sample' 'none'; form-action 'none'; frame-ancestors 'none'; report-uri /csp-report";
   default $upstream_http_content_security_policy;
 }

--- a/files/nginx/setup-odk.sh
+++ b/files/nginx/setup-odk.sh
@@ -59,7 +59,7 @@ else
     # strip out all ssl_* directives
     perl -i -ne 's/listen 443.*/listen 80;/; print if ! /\bssl_/' /etc/nginx/conf.d/odk.conf
     # force https because we expect SSL upstream
-    perl -i -pe 's/X-Forwarded-Proto \$scheme/X-Forwarded-Proto https/;' /usr/share/odk/nginx/backend.conf
+    perl -i -pe 's/X-Forwarded-Proto \$scheme/X-Forwarded-Proto https/;' /etc/nginx/conf.d/odk.conf
     echo "starting nginx for upstream ssl..."
   else
     # remove letsencrypt challenge reply, but keep 80 to 443 redirection

--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -32,7 +32,6 @@ COPY files/nginx/setup-odk.sh \
      /scripts/
 
 COPY files/nginx/redirector.conf /usr/share/odk/nginx/
-COPY files/nginx/backend.conf /usr/share/odk/nginx/
 COPY files/nginx/common-headers.conf /usr/share/odk/nginx/
 COPY files/nginx/robots.txt /usr/share/nginx/html
 COPY --from=intermediate client/dist/ /usr/share/nginx/html

--- a/test/nginx/mock-http-server/index.js
+++ b/test/nginx/mock-http-server/index.js
@@ -40,6 +40,7 @@ app.get('/v1/projects', (_, res) => {
 });
 
 app.get('/v1/oidc/callback', (req, res) => {
+  // This endpoint is 100% responsible for its own headers.  Set both, and test they both get through.
   res.set('Content-Security-Policy',             `NOTE:FROM-BACKEND:block`);
   res.set('Content-Security-Policy-Report-Only', `NOTE:FROM-BACKEND:reportOnly`);
 

--- a/test/nginx/mock-http-server/index.js
+++ b/test/nginx/mock-http-server/index.js
@@ -16,6 +16,8 @@ app.use((req, res, next) => {
 app.use('/-/', (req, res, next) => {
   res.set('Vary', 'Accept-Encoding');
   res.set('Cache-Control', 'public, max-age=0');
+  res.set('Content-Security-Policy',             `NOTE:FROM-BACKEND:block`);
+  res.set('Content-Security-Policy-Report-Only', `NOTE:FROM-BACKEND:reportOnly`);
   next();
 });
 

--- a/test/nginx/mock-http-server/index.js
+++ b/test/nginx/mock-http-server/index.js
@@ -9,16 +9,6 @@ const app = express();
 
 app.use((req, res, next) => {
   console.log(new Date(), req.method, req.originalUrl);
-
-  // always set CSP header to detect (or allow) leaks from backend through to the client
-  const topLevelDirectives = [
-    'default-src',
-    'form-action',
-    'frame-ancestors',
-  ];
-  res.set('Content-Security-Policy',             topLevelDirectives.map(d => `${d} NOTE:FROM-BACKEND:block`)     .join('; '));
-  res.set('Content-Security-Policy-Report-Only', topLevelDirectives.map(d => `${d} NOTE:FROM-BACKEND:reportOnly`).join('; '));
-
   next();
 });
 
@@ -42,6 +32,13 @@ app.get('/v1/reflect-headers', (req, res) => res.json(req.headers));
 app.get('/v1/projects', (_, res) => {
   res.set('Vary', 'Cookie');
   res.set('Cache-Control', 'private, max-age=3600');
+  res.send('OK');
+});
+
+app.get('/v1/oidc/callback', () => {
+  res.set('Content-Security-Policy',             `NOTE:FROM-BACKEND:block`);
+  res.set('Content-Security-Policy-Report-Only', `NOTE:FROM-BACKEND:reportOnly`);
+
   res.send('OK');
 });
 

--- a/test/nginx/mock-http-server/index.js
+++ b/test/nginx/mock-http-server/index.js
@@ -16,6 +16,8 @@ app.use((req, res, next) => {
 app.use('/-/', (req, res, next) => {
   res.set('Vary', 'Accept-Encoding');
   res.set('Cache-Control', 'public, max-age=0');
+
+  // Set both CSP headers from enketo.  Eventually nginx should be confident to override both.
   res.set('Content-Security-Policy',             `NOTE:FROM-BACKEND:block`);
   res.set('Content-Security-Policy-Report-Only', `NOTE:FROM-BACKEND:reportOnly`);
   next();

--- a/test/nginx/mock-http-server/index.js
+++ b/test/nginx/mock-http-server/index.js
@@ -35,7 +35,7 @@ app.get('/v1/projects', (_, res) => {
   res.send('OK');
 });
 
-app.get('/v1/oidc/callback', () => {
+app.get('/v1/oidc/callback', (req, res) => {
   res.set('Content-Security-Policy',             `NOTE:FROM-BACKEND:block`);
   res.set('Content-Security-Policy-Report-Only', `NOTE:FROM-BACKEND:reportOnly`);
 

--- a/test/nginx/src/mocha/nginx.spec.js
+++ b/test/nginx/src/mocha/nginx.spec.js
@@ -43,11 +43,6 @@ const allowGoogleTranslate = ({ 'connect-src':connectSrc, 'img-src':imgSrc, ...o
 const contentSecurityPolicies = {
   'backend-strict': {
     block: {
-      'default-src':     'NOTE:FROM-BACKEND:block',
-      'form-action':     'NOTE:FROM-BACKEND:block',
-      'frame-ancestors': 'NOTE:FROM-BACKEND:block',
-    },
-    reportOnly: {
       'default-src': [
         reportSample,
         none,

--- a/test/nginx/src/mocha/nginx.spec.js
+++ b/test/nginx/src/mocha/nginx.spec.js
@@ -108,11 +108,7 @@ const contentSecurityPolicies = {
     }),
   },
   enketo: {
-    block: {
-      'default-src':     'NOTE:FROM-BACKEND:block',
-      'form-action':     'NOTE:FROM-BACKEND:block',
-      'frame-ancestors': 'NOTE:FROM-BACKEND:block',
-    },
+    block: 'NOTE:FROM-BACKEND:block',
     reportOnly: allowGoogleTranslate({
       'default-src': [
         reportSample,
@@ -246,18 +242,22 @@ describe('Content-Security-Policy definitions', () => {
         const policy = policies[headerType];
         if(!policy) continue;
 
-        it(`should have required directives: ${requiredDirectives}`, () => {
-          assert.containsAllKeys(policy, requiredDirectives);
-        });
-
-        describe(`header: ${headerNames[headerType]}`, () => {
+        if(!(typeof policy === 'string' && policy.startsWith('NOTE:FROM-BACKEND:'))) {
           it(`should have required directives: ${requiredDirectives}`, () => {
             assert.containsAllKeys(policy, requiredDirectives);
           });
+        }
+
+        describe(`header: ${headerNames[headerType]}`, () => {
+          if(!(typeof policy === 'string' && policy.startsWith('NOTE:FROM-BACKEND:'))) {
+            it(`should have required directives: ${requiredDirectives}`, () => {
+              assert.containsAllKeys(policy, requiredDirectives);
+            });
+          }
 
           Object.entries(policy)
               .map    (([ key, directive ]) => [ key, asArray(directive) ])
-              .filter (([ key, directive ]) => !(directive.length === 1 && directive[0] === `NOTE:FROM-BACKEND:${headerType}`)) // eslint-disable-line no-unused-vars
+              .filter (([ key, directive ]) => directive.length !== 1) // eslint-disable-line no-unused-vars
               .forEach(([ key, directive ]) => {
                 describe(`directive: ${key}`, () => {
                   if(supportsReportSample.includes(key)) {

--- a/test/nginx/src/mocha/nginx.spec.js
+++ b/test/nginx/src/mocha/nginx.spec.js
@@ -53,16 +53,8 @@ const contentSecurityPolicies = {
     },
   },
   'backend-unmodified': {
-    block: {
-      'default-src':     'NOTE:FROM-BACKEND:block',
-      'form-action':     'NOTE:FROM-BACKEND:block',
-      'frame-ancestors': 'NOTE:FROM-BACKEND:block',
-    },
-    reportOnly: {
-      'default-src':     'NOTE:FROM-BACKEND:reportOnly',
-      'form-action':     'NOTE:FROM-BACKEND:reportOnly',
-      'frame-ancestors': 'NOTE:FROM-BACKEND:reportOnly',
-    },
+    block:      'NOTE:FROM-BACKEND:block',
+    reportOnly: 'NOTE:FROM-BACKEND:reportOnly',
   },
   'blank-html': {
     reportOnly: allowGoogleTranslate({
@@ -1179,9 +1171,13 @@ function assertSecurityHeaders(res, { csp }) {
 function assertCsp(actual, expected) {
   if(!expected) return assert.isNull(actual);
 
-  assert.deepEqualInAnyOrder(
-    actual?.split('; '),
-    Object.entries(expected)
-        .map(([ k, v ]) => `${k} ${asArray(v).join(' ')}`),
-  );
+  if(typeof expected === 'string') {
+    assert.equal(actual, expected);
+  } else {
+    assert.deepEqualInAnyOrder(
+      actual?.split('; '),
+      Object.entries(expected)
+          .map(([ k, v ]) => `${k} ${asArray(v).join(' ')}`),
+    );
+  }
 }

--- a/test/nginx/src/mocha/nginx.spec.js
+++ b/test/nginx/src/mocha/nginx.spec.js
@@ -252,7 +252,6 @@ describe('Content-Security-Policy definitions', () => {
 
           Object.entries(policy)
               .map    (([ key, directive ]) => [ key, asArray(directive) ])
-              .filter (([ key, directive ]) => directive.length !== 1) // eslint-disable-line no-unused-vars
               .forEach(([ key, directive ]) => {
                 describe(`directive: ${key}`, () => {
                   if(supportsReportSample.includes(key)) {

--- a/test/nginx/src/mocha/nginx.spec.js
+++ b/test/nginx/src/mocha/nginx.spec.js
@@ -245,7 +245,9 @@ describe('Content-Security-Policy definitions', () => {
         if(!policy) continue;
 
         describe(`header: ${headerNames[headerType]}`, () => {
-          if(!(typeof policy === 'string' && policy.startsWith('NOTE:FROM-BACKEND:'))) {
+          if(typeof policy === 'string') {
+            if(!policy.startsWith('NOTE:FROM-BACKEND:')) throw new Error(`Unexpected policy string: '${policy}'`);
+          } else {
             it(`should have required directives: ${requiredDirectives}`, () => {
               assert.containsAllKeys(policy, requiredDirectives);
             });

--- a/test/nginx/src/mocha/nginx.spec.js
+++ b/test/nginx/src/mocha/nginx.spec.js
@@ -251,33 +251,33 @@ describe('Content-Security-Policy definitions', () => {
             it(`should have required directives: ${requiredDirectives}`, () => {
               assert.containsAllKeys(policy, requiredDirectives);
             });
-          }
 
-          Object.entries(policy)
-              .map    (([ key, directive ]) => [ key, asArray(directive) ])
-              .forEach(([ key, directive ]) => {
-                describe(`directive: ${key}`, () => {
-                  if(supportsReportSample.includes(key)) {
-                    if(key.startsWith('style-src') && directive.includes(`'unsafe-inline'`)) {
-                      // For style-* directives, report-sample will only provide a sample of inline violations.
-                      it(`should not include 'report-sample' in directive '${key}' when 'unsafe-inline' is allowed`, () => {
+            Object.entries(policy)
+                .map    (([ key, directive ]) => [ key, asArray(directive) ])
+                .forEach(([ key, directive ]) => {
+                  describe(`directive: ${key}`, () => {
+                    if(supportsReportSample.includes(key)) {
+                      if(key.startsWith('style-src') && directive.includes(`'unsafe-inline'`)) {
+                        // For style-* directives, report-sample will only provide a sample of inline violations.
+                        it(`should not include 'report-sample' in directive '${key}' when 'unsafe-inline' is allowed`, () => {
+                          // expect
+                          assert.notInclude(directive, "'report-sample'");
+                        });
+                      } else {
+                        it(`should include 'report-sample' in directive '${key}'`, () => {
+                          // expect
+                          assert.include(directive, "'report-sample'");
+                        });
+                      }
+                    } else {
+                      it(`should not include 'report-sample' in directive '${key}'`, () => {
                         // expect
                         assert.notInclude(directive, "'report-sample'");
                       });
-                    } else {
-                      it(`should include 'report-sample' in directive '${key}'`, () => {
-                        // expect
-                        assert.include(directive, "'report-sample'");
-                      });
                     }
-                  } else {
-                    it(`should not include 'report-sample' in directive '${key}'`, () => {
-                      // expect
-                      assert.notInclude(directive, "'report-sample'");
-                    });
-                  }
+                  });
                 });
-              });
+          }
         });
       }
     });


### PR DESCRIPTION
Switch from `Content-Security-Policy-Report-Only` to `Content-Security-Policy`.

#### What has been done to verify that this works as intended?

* Long-term monitoring of CSP reports.
* updated tests

#### Why is this the best possible solution? Were any other approaches considered?

Could leave it off?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should be low-impact for backend paths - almost none of them except OIDC-related paths are viewed in-browser or expected to have HTML content.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
