### PR TITLE
nginx: fix escaping in /fonts/ matcher

### DIFF
--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -40,7 +40,7 @@ map "$request_method::$uri$is_args$args" $cache_strategy {
 
   # enketo
   ~^(GET|HEAD)::/-(/x)?/css/                 "revalidate";
-  ~^(GET|HEAD)::/-(/x)?/fonts/.*\?v=          "immutable";
+  ~^(GET|HEAD)::/-(/x)?/fonts/.*\?v=         "immutable";
   ~^(GET|HEAD)::/-(/x)?/fonts/               "revalidate";
   ~^(GET|HEAD)::/-(/x)?/images/              "revalidate";
   ~^(GET|HEAD)::/-(/x)?/js/build/chunks/     "immutable";

--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -40,7 +40,7 @@ map "$request_method::$uri$is_args$args" $cache_strategy {
 
   # enketo
   ~^(GET|HEAD)::/-(/x)?/css/                 "revalidate";
-  ~^(GET|HEAD)::/-(/x)?/fonts/.*?v=          "immutable";
+  ~^(GET|HEAD)::/-(/x)?/fonts/.*\?v=          "immutable";
   ~^(GET|HEAD)::/-(/x)?/fonts/               "revalidate";
   ~^(GET|HEAD)::/-(/x)?/images/              "revalidate";
   ~^(GET|HEAD)::/-(/x)?/js/build/chunks/     "immutable";


### PR DESCRIPTION
Noted while working on #1810

#### What has been done to verify that this works as intended?

The question mark is intended as a literal `?` rather than making the `.*` optional.

#### Why is this the best possible solution? Were any other approaches considered?

Seems like a simple change.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No likely effect - such a minor detail, expected URLs would have matched anyway.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
