### PR TITLE
service.dockerfile: move DB_SSL check to its own image

### DIFF
--- a/service.dockerfile
+++ b/service.dockerfile
@@ -2,6 +2,12 @@ ARG node_version=24.14.1
 
 
 
+FROM node:${node_version}-slim AS env_validator
+ARG DB_SSL
+RUN [ -z "${DB_SSL}" ] || (/bin/echo -e '\n\n\n\n\nYou have the DB_SSL variable defined (in your .env file, probably).\nThis variable is no longer supported from Central 2026.1 onwards.\nThere is a new way of configuring SSL for your database, please see:\n\nhttps://docs.getodk.org/central-install-digital-ocean/#using-a-custom-database-server\n\nPlease refer to the Central 2026.1.0 release notes for more information on this change.\n\n\n\n\n'; exit 13)
+
+
+
 FROM node:${node_version}-slim AS pgdg
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -15,8 +21,7 @@ RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(grep -oP 'VERSION_CODEN
     && curl https://www.postgresql.org/media/keys/ACCC4CF8.asc \
       | gpg --dearmor > /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg
 
-ARG DB_SSL
-RUN [ -z "${DB_SSL}" ] || (/bin/echo -e '\n\n\n\n\nYou have the DB_SSL variable defined (in your .env file, probably).\nThis variable is no longer supported from Central 2026.1 onwards.\nThere is a new way of configuring SSL for your database, please see:\n\nhttps://docs.getodk.org/central-install-digital-ocean/#using-a-custom-database-server\n\nPlease refer to the Central 2026.1.0 release notes for more information on this change.\n\n\n\n\n'; exit 13)
+
 
 FROM node:${node_version}-slim AS intermediate
 RUN apt-get update \
@@ -34,6 +39,7 @@ RUN git describe --tags --dirty --always > /tmp/sentry-versions/client
 
 
 FROM node:${node_version}-slim
+COPY --from=env_validator /dev/null /dev/null # Force env_validator to build
 
 ARG node_version
 LABEL org.opencontainers.image.source="https://github.com/getodk/central"


### PR DESCRIPTION
This makes the env check independent of the pgdg container.  Logically there's no connection between the check for DB_SSL (which relates to postgres configuration) and the pgdg container (which is specifically making postgres apt repositories available to the final container).

This also means that the DB_SSL check will run faster, and when appropriate, fail faster.

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
