### PR TITLE
 service: move DB_SSL check back to runtime

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,7 @@ jobs:
     - uses: actions/checkout@v5
     - run: ./test/test-secrets.sh
   test-service:
-    timeout-minutes: 2
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,6 +66,16 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - run: ./test/test-secrets.sh
+  test-service:
+    timeout-minutes: 2
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+    - uses: actions/setup-node@v5
+      with:
+        node-version: 24.14.1
+    - run: cd test/nginx && npm clean-install
+    - run: cd test/nginx && npm run test:service
   test-images:
     timeout-minutes: 10
     needs:
@@ -73,6 +83,7 @@ jobs:
     - test-envsub
     - test-nginx
     - test-secrets
+    - test-service
     runs-on: ubuntu-latest # TODO matrix to run on all expected versions?
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,6 +71,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
+      with:
+        submodules: true
     - uses: actions/setup-node@v5
       with:
         node-version: 24.14.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,8 +38,6 @@ services:
   service:
     build:
       context: .
-      args:
-        DB_SSL: ${DB_SSL:-}  # So that we can error out at build time if this is defined with a value of "true" (no longer supported from 2026.1).
       dockerfile: service.dockerfile
     depends_on:
       - secrets
@@ -68,6 +66,7 @@ services:
       - PGPASSWORD=${PGPASSWORD-${DB_PASSWORD:-odk}}
       - PGAPPNAME=${PGAPPNAME-odkcentral}
       # End of libpq connection env var preparation.
+      - DB_SSL=${DB_SSL-notset}
       - DB_POOL_SIZE=${DB_POOL_SIZE:-10}
       - EMAIL_FROM=${EMAIL_FROM:-no-reply@$DOMAIN}
       - EMAIL_HOST=${EMAIL_HOST:-mail}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       - PGPASSWORD=${PGPASSWORD-${DB_PASSWORD:-odk}}
       - PGAPPNAME=${PGAPPNAME-odkcentral}
       # End of libpq connection env var preparation.
-      - DB_SSL=${DB_SSL-notset}
+      - DB_SSL=${DB_SSL:-null}
       - DB_POOL_SIZE=${DB_POOL_SIZE:-10}
       - EMAIL_FROM=${EMAIL_FROM:-no-reply@$DOMAIN}
       - EMAIL_HOST=${EMAIL_HOST:-mail}

--- a/files/service/scripts/start-odk.sh
+++ b/files/service/scripts/start-odk.sh
@@ -3,7 +3,7 @@ set -o pipefail
 shopt -s inherit_errexit
 
 # Check for illegal DB_SSL environment variable.
-if ! [[ "${DB_SSL-}" = notset ]]; then
+if ! [[ "${DB_SSL-}" = null ]]; then
   echo "!!!"
   echo "!!! You have the DB_SSL variable defined (in your .env file, probably)."
   echo "!!! This variable is no longer supported from Central 2026.1 onwards."
@@ -18,7 +18,7 @@ if ! [[ "${DB_SSL-}" = notset ]]; then
   sleep 60 # reduce resource waste from quick restart and instant failure
   exit 1
 fi
-unset DB_SSL_CHECK
+unset DB_SSL
 
 # Serialize (as a raw env block) the environment set up by docker, for later
 # availability to processes running with a reset environment (such as cronjobs).

--- a/files/service/scripts/start-odk.sh
+++ b/files/service/scripts/start-odk.sh
@@ -2,6 +2,24 @@
 set -o pipefail
 shopt -s inherit_errexit
 
+# Check for illegal DB_SSL environment variable.
+if ! [[ "${DB_SSL-}" = notset ]]; then
+  echo "!!!"
+  echo "!!! You have the DB_SSL variable defined (in your .env file, probably)."
+  echo "!!! This variable is no longer supported from Central 2026.1 onwards."
+  echo "!!! There is a new way of configuring SSL for your database, please see:"
+  echo "!!!"
+  echo "!!!   https://docs.getodk.org/central-install-digital-ocean/#using-a-custom-database-server"
+  echo "!!!"
+  echo "!!! Please refer to the Central 2026.1.0 release notes for more information on this change."
+  echo "!!!"
+  echo "!!! ODK Central backend will not start until this issue is resolved."
+  echo "!!!"
+  sleep 60 # reduce resource waste from quick restart and instant failure
+  exit 1
+fi
+unset DB_SSL_CHECK
+
 # Serialize (as a raw env block) the environment set up by docker, for later
 # availability to processes running with a reset environment (such as cronjobs).
 # See https://github.com/getodk/central/issues/1747 .

--- a/service.dockerfile
+++ b/service.dockerfile
@@ -15,8 +15,7 @@ RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(grep -oP 'VERSION_CODEN
     && curl https://www.postgresql.org/media/keys/ACCC4CF8.asc \
       | gpg --dearmor > /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg
 
-ARG DB_SSL
-RUN [ -z "${DB_SSL}" ] || (/bin/echo -e '\n\n\n\n\nYou have the DB_SSL variable defined (in your .env file, probably).\nThis variable is no longer supported from Central 2026.1 onwards.\nThere is a new way of configuring SSL for your database, please see:\n\nhttps://docs.getodk.org/central-install-digital-ocean/#using-a-custom-database-server\n\nPlease refer to the Central 2026.1.0 release notes for more information on this change.\n\n\n\n\n'; exit 13)
+
 
 FROM node:${node_version}-slim AS intermediate
 RUN apt-get update \

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'no-trailing-spaces': 'error',
     'no-undef-init': 'error',
     'no-unused-expressions': 'error',
+    'no-unused-vars': ['error', { 'argsIgnorePattern': '^_$' }],
     'semi': [ 'error', 'always' ],
   },
 };

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -20,7 +20,6 @@ module.exports = {
     'no-trailing-spaces': 'error',
     'no-undef-init': 'error',
     'no-unused-expressions': 'error',
-    'no-unused-vars': ['error', { 'argsIgnorePattern': '^_$' }],
     'semi': [ 'error', 'always' ],
   },
 };

--- a/test/package.json
+++ b/test/package.json
@@ -6,7 +6,8 @@
     "test:nginx": "npm run test:nginx:mocha && npm run test:nginx:playwright",
     "test:nginx:mocha": "NODE_TLS_REJECT_UNAUTHORIZED=0 mocha ./nginx/src/mocha",
     "test:nginx:playwright": "NODE_TLS_REJECT_UNAUTHORIZED=0 playwright test",
-    "test": "npm run lint && npm run test:github-actions && npm run test:nginx"
+    "test:service": "mocha ./service.spec.js",
+    "test": "npm run lint && npm run test:github-actions && npm run test:nginx && npm run test:service"
   },
   "dependencies": {
     "@playwright/test": "^1.58.2",

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -16,7 +16,7 @@ describe('service image', () => {
       process.stdout.on('data', appendOutput);
       process.stderr.on('data', appendOutput);
 
-      const timer = setTimeout(() => { process.kill(); }, 4_000);
+      const timer = setTimeout(() => { process.kill(); }, 8_000);
 
       process.on('close', (code, signal) => {
         clearTimeout(timer);
@@ -38,7 +38,7 @@ describe('service image', () => {
     });
 
     it('should reject DB_SSL=true', async function() {
-      this.timeout(5000);
+      this.timeout(10_000);
 
       // when
       const { stdcombi } = await runService('--env', 'DB_SSL=true');
@@ -49,7 +49,7 @@ describe('service image', () => {
     });
 
     it('should start OK if DB_SSL is not set', async function() {
-      this.timeout(5000);
+      this.timeout(10_000);
 
       // when
       const { stdcombi } = await runService();

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -28,6 +28,7 @@ describe('service image', () => {
     before(function () {
       this.timeout(120_000);
       log('Building "service" docker image...');
+      execSync('touch .env', { cwd:'..', stdio:['ignore', 'inherit', 'inherit'] });
       execSync('docker compose build service', { cwd:'..', stdio:['ignore', 'inherit', 'inherit'] });
       log('"service" docker image built OK.');
     });

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -8,20 +8,20 @@ const log = (...args) => console.log(logPrefix, ...args);
 describe('service image', () => {
   describe('DB_SSL handling', () => {
     const runService = (...args) => new Promise(resolve => {
-      const stdout = [];
-      const stderr = [];
+      const stdcombi = [];
 
       const process = spawn('docker', [ 'compose', 'run', ...args, 'service' ], { cwd:'..' });
 
-      process.stdout.on('data', data => stdout.push(data.toString()));
-      process.stderr.on('data', data => stderr.push(data.toString()));
+      const appendOutput = data => stdcombi.push(data.toString());
+      process.stdout.on('data', appendOutput);
+      process.stderr.on('data', appendOutput);
 
       const timer = setTimeout(() => { process.kill(); }, 2_000);
 
       process.on('close', (code, signal) => {
         clearTimeout(timer);
         const asLines = datas => datas.join('').split('\n');
-        resolve({ code, signal, stdout:asLines(stdout), stderr:asLines(stderr) });
+        resolve({ code, signal, stdcombi:asLines(stdcombi) });
       });
     });
 
@@ -36,22 +36,22 @@ describe('service image', () => {
       this.timeout(5000);
 
       // when
-      const { stdout } = await runService('--env', 'DB_SSL=true');
+      const { stdcombi } = await runService('--env', 'DB_SSL=true');
 
       // then
-      assert.include(stdout, '!!! ODK Central backend will not start until this issue is resolved.');
-      assert.notInclude(stdout, 'running migrations..');
+      assert.include(stdcombi, '!!! ODK Central backend will not start until this issue is resolved.');
+      assert.notInclude(stdcombi, 'running migrations..');
     });
 
     it('should start OK if DB_SSL is not set', async function() {
       this.timeout(5000);
 
       // when
-      const { stdout } = await runService();
+      const { stdcombi } = await runService();
 
       // then
-      assert.include(stdout, 'running migrations..');
-      assert.notInclude(stdout, '!!! ODK Central backend will not start until this issue is resolved.');
+      assert.include(stdcombi, 'running migrations..');
+      assert.notInclude(stdcombi, '!!! ODK Central backend will not start until this issue is resolved.');
     });
 
     // TODO what to do for other values of DB_SSL?  what to do if DB_SSL is empty string?

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -52,29 +52,57 @@ describe('service image', () => {
       log('"service" docker image built OK.');
     });
 
-    it('should reject DB_SSL=true', async function() {
-      this.timeout(10_000);
+    describe('DB_SSL values', () => {
+      // Until pre-8e05cf3b2e8cbaa2effae2b1d3213fe23f0545cb, odk-central-backend checked
+      // DB_SSL like so:
+      // if (ssl != null && ssl !== true)
+      //   return Problem.internal.invalidDatabaseConfig({ reason: 'If ssl is specified, its value can only be true.' });
+      it('should reject DB_SSL=true', async function() {
+        this.timeout(10_000);
 
-      // when
-      const { stdcombi } = await runService('--env', 'DB_SSL=true');
+        // when
+        const { stdcombi } = await runService('--env', 'DB_SSL=true');
 
-      // then
-      assertIncludes(stdcombi, unresolvedIssue);
-      assertNotIncludes(stdcombi, generatingServiceConfig);
+        // then
+        assertIncludes(stdcombi, unresolvedIssue);
+        assertNotIncludes(stdcombi, generatingServiceConfig);
+      });
+
+      it('should start OK if DB_SSL is empty', async function() {
+        this.timeout(10_000);
+
+        // when
+        const { stdcombi } = await runService('--env', 'DB_SSL=');
+
+        // then
+        assertIncludes(stdcombi, generatingServiceConfig);
+        assertNotIncludes(stdcombi, unresolvedIssue);
+      });
+
+      it('should start OK if DB_SSL is "null"', async function() {
+        this.timeout(10_000);
+
+        // when
+        const { stdcombi } = await runService('--env', 'DB_SSL=null');
+
+        // then
+        assertIncludes(stdcombi, generatingServiceConfig);
+        assertNotIncludes(stdcombi, unresolvedIssue);
+      });
+
+      it('should start OK if DB_SSL is not set', async function() {
+        this.timeout(10_000);
+
+        // when
+        const { stdcombi } = await runService();
+
+        // then
+        assertIncludes(stdcombi, generatingServiceConfig);
+        assertNotIncludes(stdcombi, unresolvedIssue);
+      });
+
+      // TODO what to do for other values of DB_SSL?  what to do if DB_SSL is empty string?
     });
-
-    it('should start OK if DB_SSL is not set', async function() {
-      this.timeout(10_000);
-
-      // when
-      const { stdcombi } = await runService();
-
-      // then
-      assertIncludes(stdcombi, generatingServiceConfig);
-      assertNotIncludes(stdcombi, unresolvedIssue);
-    });
-
-    // TODO what to do for other values of DB_SSL?  what to do if DB_SSL is empty string?
   });
 });
 

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -16,7 +16,7 @@ describe('service image', () => {
       process.stdout.on('data', appendOutput);
       process.stderr.on('data', appendOutput);
 
-      const timer = setTimeout(() => { process.kill(); }, 2_000);
+      const timer = setTimeout(() => { process.kill(); }, 4_000);
 
       process.on('close', (code, signal) => {
         clearTimeout(timer);

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -44,8 +44,8 @@ describe('service image', () => {
       const { stdcombi } = await runService('--env', 'DB_SSL=true');
 
       // then
-      assert.include(stdcombi, '!!! ODK Central backend will not start until this issue is resolved.');
-      assert.notInclude(stdcombi, 'running migrations..');
+      assertIncludes(stdcombi, '!!! ODK Central backend will not start until this issue is resolved.');
+      assertNotIncludes(stdcombi, 'running migrations..');
     });
 
     it('should start OK if DB_SSL is not set', async function() {
@@ -55,10 +55,18 @@ describe('service image', () => {
       const { stdcombi } = await runService();
 
       // then
-      assert.include(stdcombi, 'running migrations..');
-      assert.notInclude(stdcombi, '!!! ODK Central backend will not start until this issue is resolved.');
+      assertIncludes(stdcombi, 'running migrations..');
+      assertNotIncludes(stdcombi, '!!! ODK Central backend will not start until this issue is resolved.');
     });
 
     // TODO what to do for other values of DB_SSL?  what to do if DB_SSL is empty string?
   });
 });
+
+function assertIncludes(stdcombi, expectedLine) {
+  assert.include(stdcombi, 'running migrations..', `Could not find line '${expectedLine}' in stdcombi:\n${stdcombi.join('\n')}`);
+}
+
+function assertNotIncludes(stdcombi, expectedLine) {
+  assert.notInclude(stdcombi, 'running migrations..', `Found unexpected line '${expectedLine}' in stdcombi:\n${stdcombi.join('\n')}`);
+}

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -7,11 +7,11 @@ const log = (...args) => console.log(logPrefix, ...args);
 
 describe('service image', () => {
   describe('DB_SSL handling', () => {
-    const runningMigrations = 'running migrations..';
+    const generatingServiceConfig = 'generating local service configuration..';
     const unresolvedIssue = '!!! ODK Central backend will not start until this issue is resolved.';
     const finishedMarkers = [
       unresolvedIssue,
-      runningMigrations,
+      generatingServiceConfig,
     ];
 
     const runService = (...args) => new Promise(resolve => {
@@ -60,7 +60,7 @@ describe('service image', () => {
 
       // then
       assertIncludes(stdcombi, unresolvedIssue);
-      assertNotIncludes(stdcombi, runningMigrations);
+      assertNotIncludes(stdcombi, generatingServiceConfig);
     });
 
     it('should start OK if DB_SSL is not set', async function() {
@@ -70,7 +70,7 @@ describe('service image', () => {
       const { stdcombi } = await runService();
 
       // then
-      assertIncludes(stdcombi, runningMigrations);
+      assertIncludes(stdcombi, generatingServiceConfig);
       assertNotIncludes(stdcombi, unresolvedIssue);
     });
 

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -17,7 +17,7 @@ describe('service image', () => {
       process.stderr.on('data', data => stderr.push(data.toString()));
 
       const timer = setTimeout(() => {
-        try { process.kill(); } catch(_) { }
+        try { process.kill(); } catch { /* expected */ }
       }, 2_000);
 
       process.on('close', (code, signal) => {

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -1,0 +1,24 @@
+const { execSync } = require('node:child_process');
+
+const logPrefix =`[${__filename.split('/').at(-1)}]`;
+const log = (...args) => console.log(logPrefix, ...args);
+
+describe('service image', () => {
+  describe('DB_SSL handling', () => {
+    before(() => {
+      log('Building "service" docker image...');
+      execSync('docker compose build service', { cwd:'..', stdio:['ignore', 'inherit', 'inherit'] });
+      log('"service" docker image built OK.');
+    });
+
+    it('should reject DB_SSL=true', () => {
+      throw new Error('TODO');
+    });
+
+    it('should start OK if DB_SSL is not set', () => {
+      throw new Error('TODO');
+    });
+
+    // TODO what to do for other values of DB_SSL?  what to do if DB_SSL is empty string?
+  });
+});

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -7,6 +7,18 @@ const log = (...args) => console.log(logPrefix, ...args);
 
 describe('service image', () => {
   describe('DB_SSL handling', () => {
+    // Pre-8e05cf3b2e8cbaa2effae2b1d3213fe23f0545cb, odk-central-backend checked
+    // DB_SSL like so:
+    //
+    //     if (ssl != null && ssl !== true)
+    //       return Problem.internal.invalidDatabaseConfig({ reason: 'If ssl is specified, its value can only be true.' });
+    //
+    // This was passed into config in the getodk/central repo pre-d10cccb34bb3abd893563bbe26ed5160df66b972
+    // via:
+    //
+    //     docker-compose.yml: - DB_SSL=${DB_SSL:-null}
+    //     files/service/config.json.template: "ssl": ${DB_SSL},
+
     const generatingServiceConfig = 'generating local service configuration..';
     const unresolvedIssue = '!!! ODK Central backend will not start until this issue is resolved.';
     const finishedMarkers = [
@@ -52,61 +64,47 @@ describe('service image', () => {
       log('"service" docker image built OK.');
     });
 
-    describe('DB_SSL values', () => {
-      // Pre-8e05cf3b2e8cbaa2effae2b1d3213fe23f0545cb, odk-central-backend checked
-      // DB_SSL like so:
-      //
-      //     if (ssl != null && ssl !== true)
-      //       return Problem.internal.invalidDatabaseConfig({ reason: 'If ssl is specified, its value can only be true.' });
-      //
-      // This was passed into config in the getodk/central repo pre-d10cccb34bb3abd893563bbe26ed5160df66b972
-      // via:
-      //
-      //     docker-compose.yml: - DB_SSL=${DB_SSL:-null}
-      //     files/service/config.json.template: "ssl": ${DB_SSL},
-
-      [
-        '', // e.g. if passed via `docker compose run --env DB_SSL=`
-        'true',
-        'false',
-      ].forEach(badVal => {
-        it(`should fail to start if DB_SSL=${badVal}`, async function() {
-          this.timeout(10_000);
-
-          // when
-          const { stdcombi } = await runService('--env', `DB_SSL=${badVal}`);
-
-          // then
-          assertIncludes(stdcombi, unresolvedIssue);
-          assertNotIncludes(stdcombi, generatingServiceConfig);
-        });
-      });
-
-      [
-        'null',
-      ].forEach(goodVal => {
-        it(`should start OK if DB_SSL=${goodVal}`, async function() {
-          this.timeout(10_000);
-
-          // when
-          const { stdcombi } = await runService('--env', `DB_SSL=${goodVal}`);
-
-          // then
-          assertIncludes(stdcombi, generatingServiceConfig);
-          assertNotIncludes(stdcombi, unresolvedIssue);
-        });
-      });
-
-      it('should start OK if DB_SSL is not set', async function() {
+    [
+      '', // e.g. if passed via `docker compose run --env DB_SSL=`
+      'true',
+      'false',
+    ].forEach(badVal => {
+      it(`should fail to start if DB_SSL=${badVal}`, async function() {
         this.timeout(10_000);
 
         // when
-        const { stdcombi } = await runService();
+        const { stdcombi } = await runService('--env', `DB_SSL=${badVal}`);
+
+        // then
+        assertIncludes(stdcombi, unresolvedIssue);
+        assertNotIncludes(stdcombi, generatingServiceConfig);
+      });
+    });
+
+    [
+      'null',
+    ].forEach(goodVal => {
+      it(`should start OK if DB_SSL=${goodVal}`, async function() {
+        this.timeout(10_000);
+
+        // when
+        const { stdcombi } = await runService('--env', `DB_SSL=${goodVal}`);
 
         // then
         assertIncludes(stdcombi, generatingServiceConfig);
         assertNotIncludes(stdcombi, unresolvedIssue);
       });
+    });
+
+    it('should start OK if DB_SSL is not set', async function() {
+      this.timeout(10_000);
+
+      // when
+      const { stdcombi } = await runService();
+
+      // then
+      assertIncludes(stdcombi, generatingServiceConfig);
+      assertNotIncludes(stdcombi, unresolvedIssue);
     });
   });
 });

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -53,7 +53,7 @@ describe('service image', () => {
     });
 
     describe('DB_SSL values', () => {
-      // Until pre-8e05cf3b2e8cbaa2effae2b1d3213fe23f0545cb, odk-central-backend checked
+      // Pre-8e05cf3b2e8cbaa2effae2b1d3213fe23f0545cb, odk-central-backend checked
       // DB_SSL like so:
       //
       //     if (ssl != null && ssl !== true)

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -39,7 +39,7 @@ describe('service image', () => {
       const { stdcombi } = await runService('--env', 'DB_SSL=true');
 
       // then
-      assert.include(stdcombi, '!!! ODK Central backend will not start until this issue is resolved.');
+      assert.include(stdcombi, '!!! ODK Central backend will not start until this issue is resolved.', `Full output: \n${stdcombi.join('\n')}`);
       assert.notInclude(stdcombi, 'running migrations..');
     });
 
@@ -50,7 +50,7 @@ describe('service image', () => {
       const { stdcombi } = await runService();
 
       // then
-      assert.include(stdcombi, 'running migrations..');
+      assert.include(stdcombi, 'running migrations..', `Full output: \n${stdcombi.join('\n')}`);
       assert.notInclude(stdcombi, '!!! ODK Central backend will not start until this issue is resolved.');
     });
 

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -64,9 +64,9 @@ describe('service image', () => {
 });
 
 function assertIncludes(stdcombi, expectedLine) {
-  assert.include(stdcombi, 'running migrations..', `Could not find line '${expectedLine}' in stdcombi:\n${stdcombi.join('\n')}`);
+  assert.include(stdcombi, expectedLine, `Could not find line '${expectedLine}' in stdcombi:\n${stdcombi.join('\n')}`);
 }
 
 function assertNotIncludes(stdcombi, expectedLine) {
-  assert.notInclude(stdcombi, 'running migrations..', `Found unexpected line '${expectedLine}' in stdcombi:\n${stdcombi.join('\n')}`);
+  assert.notInclude(stdcombi, expectedLine, `Found unexpected line '${expectedLine}' in stdcombi:\n${stdcombi.join('\n')}`);
 }

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -31,7 +31,7 @@ describe('service image', () => {
       process.stdout.on('data', appendOutput);
       process.stderr.on('data', appendOutput);
 
-      const timer = setTimeout(() => { process.kill(); }, 19_000);
+      const timer = setTimeout(() => { process.kill(); }, 9_000);
 
       process.on('close', (code, signal) => {
         clearTimeout(timer);
@@ -53,7 +53,7 @@ describe('service image', () => {
     });
 
     it('should reject DB_SSL=true', async function() {
-      this.timeout(20_000);
+      this.timeout(10_000);
 
       // when
       const { stdcombi } = await runService('--env', 'DB_SSL=true');
@@ -64,7 +64,7 @@ describe('service image', () => {
     });
 
     it('should start OK if DB_SSL is not set', async function() {
-      this.timeout(20_000);
+      this.timeout(10_000);
 
       // when
       const { stdcombi } = await runService();

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -40,7 +40,7 @@ describe('service image', () => {
       const { stdcombi } = await runService('--env', 'DB_SSL=true');
 
       // then
-      assert.include(stdcombi, '!!! ODK Central backend will not start until this issue is resolved.', `Full output: \n${stdcombi.join('\n')}`);
+      assert.include(stdcombi, '!!! ODK Central backend will not start until this issue is resolved.');
       assert.notInclude(stdcombi, 'running migrations..');
     });
 
@@ -51,7 +51,7 @@ describe('service image', () => {
       const { stdcombi } = await runService();
 
       // then
-      assert.include(stdcombi, 'running migrations..', `Full output: \n${stdcombi.join('\n')}`);
+      assert.include(stdcombi, 'running migrations..');
       assert.notInclude(stdcombi, '!!! ODK Central backend will not start until this issue is resolved.');
     });
 

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -7,16 +7,31 @@ const log = (...args) => console.log(logPrefix, ...args);
 
 describe('service image', () => {
   describe('DB_SSL handling', () => {
+    const runningMigrations = 'running migrations..';
+    const unresolvedIssue = '!!! ODK Central backend will not start until this issue is resolved.';
+    const finishedMarkers = [
+      unresolvedIssue,
+      runningMigrations,
+    ];
+
     const runService = (...args) => new Promise(resolve => {
       const stdcombi = [];
 
       const process = spawn('docker', [ 'compose', 'run', ...args, 'service' ], { cwd:'..' });
 
-      const appendOutput = data => stdcombi.push(data.toString());
+      const appendOutput = data => {
+        const str = data.toString();
+        stdcombi.push(str);
+
+        // Allow short-circuiting of tests - execution time varies
+        // wildly depending if docker images are pre-built or not.
+        const lines = str.split('\n');
+        if(lines.some(line => finishedMarkers.includes(line))) process.kill();
+      };
       process.stdout.on('data', appendOutput);
       process.stderr.on('data', appendOutput);
 
-      const timer = setTimeout(() => { process.kill(); }, 8_000);
+      const timer = setTimeout(() => { process.kill(); }, 19_000);
 
       process.on('close', (code, signal) => {
         clearTimeout(timer);
@@ -38,25 +53,25 @@ describe('service image', () => {
     });
 
     it('should reject DB_SSL=true', async function() {
-      this.timeout(10_000);
+      this.timeout(20_000);
 
       // when
       const { stdcombi } = await runService('--env', 'DB_SSL=true');
 
       // then
-      assertIncludes(stdcombi, '!!! ODK Central backend will not start until this issue is resolved.');
-      assertNotIncludes(stdcombi, 'running migrations..');
+      assertIncludes(stdcombi, unresolvedIssue);
+      assertNotIncludes(stdcombi, runningMigrations);
     });
 
     it('should start OK if DB_SSL is not set', async function() {
-      this.timeout(10_000);
+      this.timeout(20_000);
 
       // when
       const { stdcombi } = await runService();
 
       // then
-      assertIncludes(stdcombi, 'running migrations..');
-      assertNotIncludes(stdcombi, '!!! ODK Central backend will not start until this issue is resolved.');
+      assertIncludes(stdcombi, runningMigrations);
+      assertNotIncludes(stdcombi, unresolvedIssue);
     });
 
     // TODO what to do for other values of DB_SSL?  what to do if DB_SSL is empty string?

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -66,6 +66,7 @@ describe('service image', () => {
       //     files/service/config.json.template: "ssl": ${DB_SSL},
 
       [
+        '', // e.g. if passed via `docker compose run --env DB_SSL=`
         'true',
         'false',
       ].forEach(badVal => {
@@ -82,7 +83,6 @@ describe('service image', () => {
       });
 
       [
-        '',
         'null',
       ].forEach(goodVal => {
         it(`should start OK if DB_SSL=${goodVal}`, async function() {

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -16,9 +16,7 @@ describe('service image', () => {
       process.stdout.on('data', data => stdout.push(data.toString()));
       process.stderr.on('data', data => stderr.push(data.toString()));
 
-      const timer = setTimeout(() => {
-        try { process.kill(); } catch { /* expected */ }
-      }, 2_000);
+      const timer = setTimeout(() => { process.kill(); }, 2_000);
 
       process.on('close', (code, signal) => {
         clearTimeout(timer);

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -27,9 +27,13 @@ describe('service image', () => {
 
     before(function () {
       this.timeout(120_000);
+
+      const exec = cmd => execSync(cmd, { cwd:'..', stdio:['ignore', 'inherit', 'inherit'] });
+
       log('Building "service" docker image...');
-      execSync('touch .env', { cwd:'..', stdio:['ignore', 'inherit', 'inherit'] });
-      execSync('docker compose build service', { cwd:'..', stdio:['ignore', 'inherit', 'inherit'] });
+      exec('touch .env');
+      exec('docker compose pull --include-deps service');
+      exec('docker compose build --with-dependencies service');
       log('"service" docker image built OK.');
     });
 

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -1,22 +1,59 @@
-const { execSync } = require('node:child_process');
+const { execSync, spawn } = require('node:child_process');
+
+const { assert } = require('chai');
 
 const logPrefix =`[${__filename.split('/').at(-1)}]`;
 const log = (...args) => console.log(logPrefix, ...args);
 
 describe('service image', () => {
   describe('DB_SSL handling', () => {
-    before(() => {
+    const runService = (...args) => new Promise(resolve => {
+      const stdout = [];
+      const stderr = [];
+
+      const process = spawn('docker', [ 'compose', 'run', ...args, 'service' ], { cwd:'..' });
+
+      process.stdout.on('data', data => stdout.push(data.toString()));
+      process.stderr.on('data', data => stderr.push(data.toString()));
+
+      const timer = setTimeout(() => {
+        try { process.kill(); } catch(_) { }
+      }, 2_000);
+
+      process.on('close', (code, signal) => {
+        clearTimeout(timer);
+        const asLines = datas => datas.join('').split('\n');
+        resolve({ code, signal, stdout:asLines(stdout), stderr:asLines(stderr) });
+      });
+    });
+
+    before(function () {
+      this.timeout(120_000);
       log('Building "service" docker image...');
       execSync('docker compose build service', { cwd:'..', stdio:['ignore', 'inherit', 'inherit'] });
       log('"service" docker image built OK.');
     });
 
-    it('should reject DB_SSL=true', () => {
-      throw new Error('TODO');
+    it('should reject DB_SSL=true', async function() {
+      this.timeout(5000);
+
+      // when
+      const { stdout } = await runService('--env', 'DB_SSL=true');
+
+      // then
+      assert.include(stdout, '!!! ODK Central backend will not start until this issue is resolved.');
+      assert.notInclude(stdout, 'running migrations..');
     });
 
-    it('should start OK if DB_SSL is not set', () => {
-      throw new Error('TODO');
+    it('should start OK if DB_SSL is not set', async function() {
+      this.timeout(5000);
+
+      // when
+      const { stdout } = await runService();
+
+      // then
+      assert.include(stdout, 'running migrations..');
+      assert.notInclude(stdout, '!!! ODK Central backend will not start until this issue is resolved.');
     });
 
     // TODO what to do for other values of DB_SSL?  what to do if DB_SSL is empty string?

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -55,39 +55,46 @@ describe('service image', () => {
     describe('DB_SSL values', () => {
       // Until pre-8e05cf3b2e8cbaa2effae2b1d3213fe23f0545cb, odk-central-backend checked
       // DB_SSL like so:
-      // if (ssl != null && ssl !== true)
-      //   return Problem.internal.invalidDatabaseConfig({ reason: 'If ssl is specified, its value can only be true.' });
-      it('should reject DB_SSL=true', async function() {
-        this.timeout(10_000);
+      //
+      //     if (ssl != null && ssl !== true)
+      //       return Problem.internal.invalidDatabaseConfig({ reason: 'If ssl is specified, its value can only be true.' });
+      //
+      // This was passed into config in the getodk/central repo pre-d10cccb34bb3abd893563bbe26ed5160df66b972
+      // via:
+      //
+      //     docker-compose.yml: - DB_SSL=${DB_SSL:-null}
+      //     files/service/config.json.template: "ssl": ${DB_SSL},
 
-        // when
-        const { stdcombi } = await runService('--env', 'DB_SSL=true');
+      [
+        'true',
+        'false',
+      ].forEach(badVal => {
+        it(`should fail to start if DB_SSL=${badVal}`, async function() {
+          this.timeout(10_000);
 
-        // then
-        assertIncludes(stdcombi, unresolvedIssue);
-        assertNotIncludes(stdcombi, generatingServiceConfig);
+          // when
+          const { stdcombi } = await runService('--env', `DB_SSL=${badVal}`);
+
+          // then
+          assertIncludes(stdcombi, unresolvedIssue);
+          assertNotIncludes(stdcombi, generatingServiceConfig);
+        });
       });
 
-      it('should start OK if DB_SSL is empty', async function() {
-        this.timeout(10_000);
+      [
+        '',
+        'null',
+      ].forEach(goodVal => {
+        it(`should start OK if DB_SSL=${goodVal}`, async function() {
+          this.timeout(10_000);
 
-        // when
-        const { stdcombi } = await runService('--env', 'DB_SSL=');
+          // when
+          const { stdcombi } = await runService('--env', `DB_SSL=${goodVal}`);
 
-        // then
-        assertIncludes(stdcombi, generatingServiceConfig);
-        assertNotIncludes(stdcombi, unresolvedIssue);
-      });
-
-      it('should start OK if DB_SSL is "null"', async function() {
-        this.timeout(10_000);
-
-        // when
-        const { stdcombi } = await runService('--env', 'DB_SSL=null');
-
-        // then
-        assertIncludes(stdcombi, generatingServiceConfig);
-        assertNotIncludes(stdcombi, unresolvedIssue);
+          // then
+          assertIncludes(stdcombi, generatingServiceConfig);
+          assertNotIncludes(stdcombi, unresolvedIssue);
+        });
       });
 
       it('should start OK if DB_SSL is not set', async function() {
@@ -100,8 +107,6 @@ describe('service image', () => {
         assertIncludes(stdcombi, generatingServiceConfig);
         assertNotIncludes(stdcombi, unresolvedIssue);
       });
-
-      // TODO what to do for other values of DB_SSL?  what to do if DB_SSL is empty string?
     });
   });
 });


### PR DESCRIPTION
The `DB_SSL` env var was made illegal in https://github.com/getodk/central/pull/1647.

The check was then moved from runtime to build time in https://github.com/getodk/central/pull/1671.

Checking at build-time allows for faster failure and clearer feedback to sysadmins who are upgrading, and previously depended on this env var.  However, the downside is that if container images are pre-built centrally, this check will be skipped.

With this commit, the check will move to container startup.  However, it will now be skipped if the container is started with a non-standard CMD/command/COMMAND.

#### What has been done to verify that this works as intended?

- [x] tests
- [x] Checked locally with `docker compose up service`.  Logs as follows:

```
service-1  | 2026-05-08T09:17:20.120152694Z !!!
service-1  | 2026-05-08T09:17:20.120169026Z !!! You have the DB_SSL variable defined (in your .env file, probably).
service-1  | 2026-05-08T09:17:20.120172803Z !!! This variable is no longer supported from Central 2026.1 onwards.
service-1  | 2026-05-08T09:17:20.120183784Z !!! There is a new way of configuring SSL for your database, please see:
service-1  | 2026-05-08T09:17:20.120185848Z !!!
service-1  | 2026-05-08T09:17:20.120187712Z !!!   https://docs.getodk.org/central-install-digital-ocean/#using-a-custom-database-server
service-1  | 2026-05-08T09:17:20.120189726Z !!!
service-1  | 2026-05-08T09:17:20.120191429Z !!! Please refer to the Central 2026.1.0 release notes for more information on this change.
service-1  | 2026-05-08T09:17:20.120193163Z !!!
service-1  | 2026-05-08T09:17:20.120194886Z !!! ODK Central backend will not start until this issue is resolved.
service-1  | 2026-05-08T09:17:20.120197351Z !!!
service-1 exited with code 1 (restarting)
service-1  | 2026-05-08T09:18:20.387388287Z !!!
service-1  | 2026-05-08T09:18:20.387400901Z !!! You have the DB_SSL variable defined (in your .env file, probably).
service-1  | 2026-05-08T09:18:20.387404328Z !!! This variable is no longer supported from Central 2026.1 onwards.
service-1  | 2026-05-08T09:18:20.387407274Z !!! There is a new way of configuring SSL for your database, please see:
service-1  | 2026-05-08T09:18:20.387410039Z !!!
service-1  | 2026-05-08T09:18:20.387413055Z !!!   https://docs.getodk.org/central-install-digital-ocean/#using-a-custom-database-server
service-1  | 2026-05-08T09:18:20.387416000Z !!!
service-1  | 2026-05-08T09:18:20.387420369Z !!! Please refer to the Central 2026.1.0 release notes for more information on this change.
service-1  | 2026-05-08T09:18:20.387423204Z !!!
service-1  | 2026-05-08T09:18:20.387425910Z !!! ODK Central backend will not start until this issue is resolved.
service-1  | 2026-05-08T09:18:20.387428705Z !!!
service-1 exited with code 1 (restarting)
service-1  | 2026-05-08T09:19:20.651362541Z !!!
service-1  | 2026-05-08T09:19:20.651374394Z !!! You have the DB_SSL variable defined (in your .env file, probably).
service-1  | 2026-05-08T09:19:20.651377179Z !!! This variable is no longer supported from Central 2026.1 onwards.
service-1  | 2026-05-08T09:19:20.651379454Z !!! There is a new way of configuring SSL for your database, please see:
service-1  | 2026-05-08T09:19:20.651381638Z !!!
service-1  | 2026-05-08T09:19:20.651383802Z !!!   https://docs.getodk.org/central-install-digital-ocean/#using-a-custom-database-server
service-1  | 2026-05-08T09:19:20.651386167Z !!!
service-1  | 2026-05-08T09:19:20.651388321Z !!! Please refer to the Central 2026.1.0 release notes for more information on this change.
service-1  | 2026-05-08T09:19:20.651390545Z !!!
service-1  | 2026-05-08T09:19:20.651392709Z !!! ODK Central backend will not start until this issue is resolved.
service-1  | 2026-05-08T09:19:20.651394944Z !!!
service-1 exited with code 1 (restarting)
service-1  | 2026-05-08T09:20:20.934397647Z !!!
service-1  | 2026-05-08T09:20:20.934408808Z !!! You have the DB_SSL variable defined (in your .env file, probably).
service-1  | 2026-05-08T09:20:20.934411524Z !!! This variable is no longer supported from Central 2026.1 onwards.
service-1  | 2026-05-08T09:20:20.934413768Z !!! There is a new way of configuring SSL for your database, please see:
service-1  | 2026-05-08T09:20:20.934417155Z !!!
service-1  | 2026-05-08T09:20:20.934419359Z !!!   https://docs.getodk.org/central-install-digital-ocean/#using-a-custom-database-server
service-1  | 2026-05-08T09:20:20.934421994Z !!!
service-1  | 2026-05-08T09:20:20.934424208Z !!! Please refer to the Central 2026.1.0 release notes for more information on this change.
service-1  | 2026-05-08T09:20:20.934426433Z !!!
service-1  | 2026-05-08T09:20:20.934428627Z !!! ODK Central backend will not start until this issue is resolved.
service-1  | 2026-05-08T09:20:20.934430781Z !!!
service-1 exited with code 1 (restarting)
service-1  | 2026-05-08T09:21:21.207766916Z !!!
service-1  | 2026-05-08T09:21:21.207780743Z !!! You have the DB_SSL variable defined (in your .env file, probably).
service-1  | 2026-05-08T09:21:21.207784450Z !!! This variable is no longer supported from Central 2026.1 onwards.
service-1  | 2026-05-08T09:21:21.207787266Z !!! There is a new way of configuring SSL for your database, please see:
service-1  | 2026-05-08T09:21:21.207790021Z !!!
service-1  | 2026-05-08T09:21:21.207792776Z !!!   https://docs.getodk.org/central-install-digital-ocean/#using-a-custom-database-server
service-1  | 2026-05-08T09:21:21.207795752Z !!!
service-1  | 2026-05-08T09:21:21.207798507Z !!! Please refer to the Central 2026.1.0 release notes for more information on this change.
service-1  | 2026-05-08T09:21:21.207801213Z !!!
service-1  | 2026-05-08T09:21:21.207803938Z !!! ODK Central backend will not start until this issue is resolved.
```

#### Why is this the best possible solution? Were any other approaches considered?

Checking at build-time allows for faster failure and clearer feedback to sysadmins who are upgrading, and previously depended on this env var. However, the downside is that if container images are pre-built centrally, this check will be skipped.

This check will also now be skipped if the container is started with a non-standard CMD/command/COMMAND.

An alternative might be to include the check into `files/service/with-pgenvblock.pl`, which IIUC is intended to be run in any situation where env vars should be injected into a container command.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

I don't think this should affect users.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

I don't think so.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
