### PR TITLE
ci: simplify checkout

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,20 +33,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
-      with:
-        fetch-depth: 0
-        fetch-tags: true
-        submodules: recursive
     - run: cd test/envsub && ./run-tests.sh
   test-nginx:
     timeout-minutes: 4
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
-      with:
-        fetch-depth: 0
-        fetch-tags: true
-        submodules: recursive
     - uses: actions/setup-node@v5
       with:
         node-version: 24.14.1


### PR DESCRIPTION
It looks like the checkout code from the `test-images` job was copy/pasted elsewhere.

Simplifying this config should speed up git checkout in affected jobs by a few seconds.

#### What has been done to verify that this works as intended?

CI.

#### Why is this the best possible solution? Were any other approaches considered?

Simpler, faster; no.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect - just CI.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
