### PR TITLE
Fixes/install openssl

### DIFF
--- a/service.dockerfile
+++ b/service.dockerfile
@@ -52,6 +52,7 @@ RUN apt-get update \
         procps \
         postgresql-client-14 \
         netcat-traditional \
+        openssl \
     && rm -rf /var/lib/apt/lists/* \
     && npm clean-install --omit=dev --no-audit \
         --fund=false --update-notifier=false


### PR DESCRIPTION
Backup/restore functionality now requires `openssl` for encryption and decryption.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
