### PR TITLE
Fixes: expected docker context is increased due to WF merge

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
         fetch-depth: 0
         fetch-tags: true
         submodules: recursive
-    - run: ./test/check-docker-context.sh --min-size 50000 --max-size 60000 --min-count 1500 --max-count 1700
+    - run: ./test/check-docker-context.sh --min-size 50000 --max-size 100000 --min-count 1500 --max-count 1700
     - run: ./test/test-images.sh
     - if: always()
       run: docker compose logs


### PR DESCRIPTION
Size of git db (objects) has increase quite a bit after merging web-forms code into central-frontend, therefore increasing expected file size of docker context.

I am wondering if there is a way not to include git objects in the docker context but we rely on them to generate version.txt. Maybe once we start publishing built images we can get rid of them.

_PS: Found this issue while working on a separate issue. To understand the root cause I rerun GH Actions on `next` and `master` branches even those were failing with everything (OS, runner, git version, docker version) being same e.g. https://github.com/getodk/central/actions/runs/25595119221/job/76010520926. Only difference I could see was `git/objects/pack/pack*`._ 

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
