### PR TITLE
dev/docker-compose: restrict open ports to local machine

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -11,7 +11,7 @@ services:
     profiles:
       - central
     ports:
-      - 5432:5432
+      - 127.0.0.1:5432:5432
     environment:
       POSTGRES_USER: jubilant
       POSTGRES_PASSWORD: jubilant
@@ -39,7 +39,7 @@ services:
     profiles:
       - central
     ports:
-      - 5001:80
+      - 127.0.0.1:5001:80
   secrets:
     profiles:
       - central
@@ -61,16 +61,16 @@ services:
     extra_hosts:
     - "${DOMAIN}:host-gateway"
     ports:
-      - 8005:8005
+      - 127.0.0.1:8005:8005
   enketo_redis_main:
     profiles:
       - central
     ports:
-      - 6379:6379
+      - 127.0.0.1:6379:6379
   enketo_redis_cache:
     profiles:
       - central
     ports:
-      - 6380:6380
+      - 127.0.0.1:6380:6380
 volumes:
   dev_secrets:


### PR DESCRIPTION
Restrict TCP ports to the local machine.  This will prevent exposing these dev services on the local network or wider.

#### What has been done to verify that this works as intended?

- [x] tested locally

#### Why is this the best possible solution? Were any other approaches considered?

Should not change dev workflows, while resolving an issue.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect - just dev.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
