### PR TITLE
nginx: test stream interruption

### DIFF
--- a/test/nginx/mock-http-server/index.js
+++ b/test/nginx/mock-http-server/index.js
@@ -47,6 +47,17 @@ app.get('/v1/oidc/callback', (req, res) => {
   res.send('OK');
 });
 
+app.get('/v1/broken-stream', (req, res) => {
+  res.status(200);
+  res.write('beginning stream...', () => {
+    // Write has now flushed from NodeJS.  Give it a chance to flush
+    // from lower-level network buffer.
+    setTimeout(() => {
+       res.socket.destroy();
+    }, 50);
+  });
+});
+
 [
   'delete',
   'get',

--- a/test/nginx/mock-sentry/index.js
+++ b/test/nginx/mock-sentry/index.js
@@ -1,4 +1,5 @@
 const { execSync } = require('node:child_process');
+const crypto  = require('node:crypto');
 const { readFileSync } = require('node:fs');
 const { createServer } = require('node:https');
 const { createSecureContext } = require('node:tls');
@@ -102,6 +103,8 @@ const server = (() => {
       }
       cb(null, createSecureContext(goodCreds));
     },
+    // Without this setting, nginx pools connections to mock-sentry which are then missing SNI info when re-used.
+    secureOptions: crypto.constants.SSL_OP_NO_TICKET,
   };
 
   return createServer(opts, app);

--- a/test/nginx/mock-sentry/index.js
+++ b/test/nginx/mock-sentry/index.js
@@ -103,9 +103,8 @@ const server = (() => {
       }
       cb(null, createSecureContext(goodCreds));
     },
-    // Disable TLS session-ticket resumption so nginx does not pool HTTPS
-    // connections.  This means that repeated nginx requests will perform
-    // a full TLS handshake and exercise SNICallback consistently.
+    // Disable TLS session-ticket resumption to force nginx to perform
+    // a full TLS handshake, thus exercising SNICallback consistently.
     // See: https://nodejs.org/api/crypto.html#openssl-options:~:text=SSL_OP_NO_TICKET
     secureOptions: crypto.constants.SSL_OP_NO_TICKET,
   };

--- a/test/nginx/mock-sentry/index.js
+++ b/test/nginx/mock-sentry/index.js
@@ -103,7 +103,10 @@ const server = (() => {
       }
       cb(null, createSecureContext(goodCreds));
     },
-    // Without this setting, nginx pools connections to mock-sentry which are then missing SNI info when re-used.
+    // Disable TLS session-ticket resumption so nginx does not pool HTTPS
+    // connections.  This means that repeated nginx requests will perform
+    // a full TLS handshake and exercise SNICallback consistently.
+    // See: https://nodejs.org/api/crypto.html#openssl-options:~:text=SSL_OP_NO_TICKET
     secureOptions: crypto.constants.SSL_OP_NO_TICKET,
   };
 

--- a/test/nginx/src/mocha/nginx.spec.js
+++ b/test/nginx/src/mocha/nginx.spec.js
@@ -643,17 +643,18 @@ function standardTestSuite({ fetchHttp, fetchHttp6, apiFetch, apiFetch6, forward
   });
 
   it('should detect backend stream breakages', async () => {
-     // when
+    // when
     const res = await apiFetch('/v1/broken-stream');
-
     // then
     assert.equal(res.status, 200);
 
-    // and
     try {
+      // when
       await res.text();
+
       assert.fail('response should have been aborted');
     } catch(err) {
+      // then
       if(err.code !== 'ECONNRESET') throw err;
     }
   });

--- a/test/nginx/src/mocha/nginx.spec.js
+++ b/test/nginx/src/mocha/nginx.spec.js
@@ -642,6 +642,22 @@ function standardTestSuite({ fetchHttp, fetchHttp6, apiFetch, apiFetch6, forward
     );
   });
 
+  it('should detect backend stream breakages', async () => {
+     // when
+    const res = await apiFetch('/v1/broken-stream');
+
+    // then
+    assert.equal(res.status, 200);
+
+    // and
+    try {
+      await res.text();
+      assert.fail('response should have been aborted');
+    } catch(err) {
+      if(err.code !== 'ECONNRESET') throw err;
+    }
+  });
+
   it('/oidc/callback should serve Content-Security-Policy from backend', async () => {
     // when
     const res = await apiFetch('/v1/oidc/callback');


### PR DESCRIPTION


#### What has been done to verify that this works as intended?

- [x] run tests locally
- [x] run tests in CI
- [x] demonstrated tests fail with:
    - [x] nginx 1.29.5: https://github.com/alxndrsn/odk-central/actions/runs/26883294997/job/79288645220
    - [x] nginx 1.29.6: https://github.com/alxndrsn/odk-central/actions/runs/26884263668/job/79292069946
    
```
  2 failing

  1) nginx config
       SSL_TYPE=selfsign
         should detect backend stream breakages:
     AssertionError: response should have been aborted
      at Context.<anonymous> (nginx/src/mocha/nginx.spec.js:655:14)
      at process.processTicksAndRejections (node:internal/process/task_queues:104:5)

  2) nginx config
       SSL_TYPE=upstream
         should detect backend stream breakages:
     AssertionError: response should have been aborted
      at Context.<anonymous> (nginx/src/mocha/nginx.spec.js:655:14)
      at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
```

#### Why is this the best possible solution? Were any other approaches considered?

* nothing to fix, so no need to change nginx config
* regression should now be detected

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect - just a test.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No, it's just a test.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
