### PR TITLE
test/nginx: prevent request() from normalising paths

### DIFF
--- a/test/nginx/src/mocha/nginx.spec.js
+++ b/test/nginx/src/mocha/nginx.spec.js
@@ -1,3 +1,4 @@
+const { isIPv6 } = require('node:net');
 const tls = require('node:tls');
 const { Readable } = require('stream');
 
@@ -1087,13 +1088,20 @@ async function resetMock(port) {
 //
 // 1. do not follow redirects
 // 2. allow overriding of fetch's "forbidden" headers: https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name
-function request(url, { body, ...options }={}) {
+function request(urlString, { body, ...options }={}) {
   if(!options.headers) options.headers = {};
   if(!options.headers.host) options.headers.host = 'odk-nginx.example.test';
 
+  const url = new URL(urlString);
+  if(url.username || url.password) throw new Error('Basic auth creds not yet supported.');
+
+  options.host = safeIpv6(url.hostname);
+  options.port = url.port;
+  options.path = urlString.replace(/^http(s?):\/\/[^/]*/, '') || '/';
+
   return new Promise((resolve, reject) => {
     try {
-      const req = getProtocolImplFrom(url).request(url, options, res => {
+      const req = getProtocolImplFrom(url).request(options, res => {
         res.on('error', reject);
 
         const body = new Readable({ read:() => {} });
@@ -1129,8 +1137,7 @@ function request(url, { body, ...options }={}) {
   });
 }
 
-function getProtocolImplFrom(url) {
-  const { protocol } = new URL(url);
+function getProtocolImplFrom({ protocol }) {
   switch(protocol) {
     case 'http:':  return require('node:http');
     case 'https:': return require('node:https');
@@ -1193,4 +1200,9 @@ function assertCsp(actual, expected) {
           .map(([ k, v ]) => `${k} ${asArray(v).join(' ')}`),
     );
   }
+}
+
+function safeIpv6(hostname) {
+  const maybeV6 = hostname.replace(/^\[(.*)\]$/, (_, $1) => $1);
+  return isIPv6(maybeV6) ? maybeV6 : hostname;
 }

--- a/test/nginx/src/mocha/request.js
+++ b/test/nginx/src/mocha/request.js
@@ -7,20 +7,13 @@ module.exports = request;
 //
 // 1. do not follow redirects
 // 2. allow overriding of fetch's "forbidden" headers: https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name
-function request(urlString, { body, ...options }={}) {
+function request(url, { body, ...options }={}) {
   if(!options.headers) options.headers = {};
   if(!options.headers.host) options.headers.host = 'odk-nginx.example.test';
 
-  const url = new URL(urlString);
-  if(url.username || url.password) throw new Error('Basic auth creds not yet supported.');
-
-  options.host = safeIpv6(url.hostname);
-  options.port = url.port;
-  options.path = urlString.replace(/^http(s?):\/\/[^/]*/, '') || '/';
-
   return new Promise((resolve, reject) => {
     try {
-      const req = getProtocolImplFrom(url).request(options, res => {
+      const req = getProtocolImplFrom(url).request({ ...options, ...preserve(url) }, res => {
         res.on('error', reject);
 
         const body = new Readable({ read:() => {} });
@@ -56,12 +49,30 @@ function request(urlString, { body, ...options }={}) {
   });
 }
 
-function getProtocolImplFrom({ protocol }) {
+function getProtocolImplFrom(url) {
+  const { protocol } = new URL(url);
   switch(protocol) {
     case 'http:':  return require('node:http');
     case 'https:': return require('node:https');
     default: throw new Error(`Unsupported protocol: ${protocol}`);
   }
+}
+
+/**
+ * Prevent URL path normalisation.
+ *
+ * @see https://nodejs.org/api/http.html#httprequesturl-options-callback
+ * @see https://nodejs.org/api/url.html#new-urlinput-base
+ */
+function preserve(urlString) {
+  const url = new URL(urlString);
+  if(url.username || url.password) throw new Error('Basic auth creds not yet supported.');
+
+  const host = safeIpv6(url.hostname);
+  const port = url.port;
+  const path = urlString.replace(/^http(s?):\/\/[^/]*/, '') || '/';
+
+  return { host, port, path };
 }
 
 function safeIpv6(hostname) {

--- a/test/nginx/src/mocha/request.js
+++ b/test/nginx/src/mocha/request.js
@@ -20,7 +20,7 @@ function request(urlString, { body, ...options }={}) {
 
   return new Promise((resolve, reject) => {
     try {
-      const req = getProtocolImplFrom(url).request(url, options, res => {
+      const req = getProtocolImplFrom(url).request(options, res => {
         res.on('error', reject);
 
         const body = new Readable({ read:() => {} });

--- a/test/nginx/src/mocha/request.js
+++ b/test/nginx/src/mocha/request.js
@@ -60,7 +60,6 @@ function getProtocolImplFrom(url) {
 
 /**
  * Prevent URL path normalisation.
- *
  * @see https://nodejs.org/api/http.html#httprequesturl-options-callback
  * @see https://nodejs.org/api/url.html#new-urlinput-base
  */

--- a/test/nginx/src/mocha/request.spec.js
+++ b/test/nginx/src/mocha/request.spec.js
@@ -15,8 +15,8 @@ describe('request()', () => {
 
     const app = express();
     app.use((req, res, next) => {
-      const { method, originalUrl:path, headers } = req;
-      requestsReceived.push({ method, path, headers });
+      const { method, originalUrl:target, headers } = req;
+      requestsReceived.push({ method, target, headers });
       next();
     });
     app.get('/redirect-302', (req, res) => {
@@ -46,7 +46,7 @@ describe('request()', () => {
     assert.equal(res.status, 302);
     assert.equal(res.headers.get('location'), 'http://example.test/redirected');
     assert.deepEqual(stripHeaders(requestsReceived), [
-      { method:'GET', path:'/redirect-302' },
+      { method:'GET', target:'/redirect-302' },
     ]);
   });
 
@@ -62,7 +62,7 @@ describe('request()', () => {
     // then
     assert.equal(res.status, 200);
     assert.deepEqual(stripHeaders(requestsReceived), [
-      { method:'GET', path:'/' },
+      { method:'GET', target:'/' },
     ]);
     assert.equal(requestsReceived[0].headers['host'], 'not-a-host');
   });
@@ -74,7 +74,7 @@ describe('request()', () => {
     // then
     assert.equal(res.status, 200);
     assert.deepEqual(stripHeaders(requestsReceived), [
-      { method:'GET', path:'/a/../b.html?x=1' },
+      { method:'GET', target:'/a/../b.html?x=1' },
     ]);
   });
 });

--- a/test/nginx/src/mocha/request.spec.js
+++ b/test/nginx/src/mocha/request.spec.js
@@ -15,7 +15,7 @@ describe('request()', () => {
 
     const app = express();
     app.use((req, res, next) => {
-      const { method, path, headers } = req;
+      const { method, originalUrl:path, headers } = req;
       requestsReceived.push({ method, path, headers });
       next();
     });
@@ -65,6 +65,17 @@ describe('request()', () => {
       { method:'GET', path:'/' },
     ]);
     assert.equal(requestsReceived[0].headers['host'], 'not-a-host');
+  });
+
+  it('should not normalise URLs', async () => {
+    // when
+    const res = await request(`http://127.0.0.1:${port}/a/../b.html?x=1`);
+
+    // then
+    assert.equal(res.status, 200);
+    assert.deepEqual(stripHeaders(requestsReceived), [
+      { method:'GET', path:'/a/../b.html?x=1' },
+    ]);
   });
 });
 


### PR DESCRIPTION
This will be useful for testing nginx config at some point, and very misleading if trying to test path normalisation differences and `request()` collapses path traversals.

#### What has been done to verify that this works as intended?

* existing tests pass
* checked with new tests relating to collapsed path-traversal

#### Why is this the best possible solution? Were any other approaches considered?

While not immediately used, this will be useful for testing nginx config at some point, and very misleading if trying to test path normalisation differences and `request()` collapses path traversals.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
