### PR TITLE
 test: make ExpressJS host-bindings explicit

### DIFF
--- a/test/nginx/mock-http-server/index.js
+++ b/test/nginx/mock-http-server/index.js
@@ -70,6 +70,6 @@ app.get('/v1/broken-stream', (req, res) => {
   res.send('OK');
 }));
 
-app.listen(port, () => {
+app.listen(port, '127.0.0.1', () => {
   log(`Listening on port: ${port}`);
 });

--- a/test/nginx/mock-http-server/index.js
+++ b/test/nginx/mock-http-server/index.js
@@ -70,6 +70,6 @@ app.get('/v1/broken-stream', (req, res) => {
   res.send('OK');
 }));
 
-app.listen(port, '127.0.0.1', () => {
+app.listen(port, '0.0.0.0', () => {
   log(`Listening on port: ${port}`);
 });

--- a/test/nginx/mock-sentry/index.js
+++ b/test/nginx/mock-sentry/index.js
@@ -112,7 +112,7 @@ const server = (() => {
   return createServer(opts, app);
 })();
 
-server.listen(port, () => {
+server.listen(port, '127.0.0.1', () => {
   log(`Listening with HTTPS on port: ${port}`);
 });
 

--- a/test/nginx/mock-sentry/index.js
+++ b/test/nginx/mock-sentry/index.js
@@ -112,7 +112,7 @@ const server = (() => {
   return createServer(opts, app);
 })();
 
-server.listen(port, '127.0.0.1', () => {
+server.listen(port, '0.0.0.0', () => {
   log(`Listening with HTTPS on port: ${port}`);
 });
 


### PR DESCRIPTION
#### What has been done to verify that this works as intended?

CI.

#### Why is this the best possible solution? Were any other approaches considered?

These servers need to be available to their local networks so that when their docker containers' ports are published, the underlying express services can be accessed from the docker host machine.

This PR doesn't change behaviour, but it makes the intent of the `listen()` calls more explicit.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced