### PR TITLE
ci: read node version from volta declaration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
     - uses: actions/checkout@v5
     - uses: actions/setup-node@v5
       with:
-        node-version: 24.14.1
+        node-version-file: test/package.json
     - run: cd test/nginx && npm clean-install
     - run: cd test/nginx && ./setup-tests.sh
     - run: cd test/nginx && npm run test:nginx:mocha
@@ -75,7 +75,7 @@ jobs:
         submodules: true
     - uses: actions/setup-node@v5
       with:
-        node-version: 24.14.1
+        node-version-file: test/package.json
     - run: cd test/nginx && npm clean-install
     - run: cd test/nginx && npm run test:service
   test-images:


### PR DESCRIPTION
One less place to keep up-to-date.

#### What has been done to verify that this works as intended?

- [x] checked CI logs `setup-node` step to confirm the expected version is configured

#### Why is this the best possible solution? Were any other approaches considered?

Version drift is unhelpful.  This change should reduce the chance of version drift.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced