### PR TITLE
test/check-docker-context: ignore .git directory

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,7 +93,7 @@ jobs:
         fetch-depth: 0
         fetch-tags: true
         submodules: recursive
-    - run: ./test/check-docker-context.sh --min-size 90000 --max-size 110000 --min-count 1500 --max-count 1700
+    - run: ./test/check-docker-context.sh --min-size 15000 --max-size 25000 --min-count 1400 --max-count 1500
     - run: ./test/test-images.sh
     - if: always()
       run: docker compose logs

--- a/test/check-docker-context.sh
+++ b/test/check-docker-context.sh
@@ -59,6 +59,13 @@ docker \
 FROM busybox
 COPY . /build-context
 WORKDIR /build-context
+
+# Ignore .git files - ideally they wouldn't be included in the Docker
+# context, but while they still are they cloud these checks because
+# their count and size can vary between branches/forks/PRs.
+# See: https://github.com/getodk/central/issues/1810
+RUN rm -rf ./.git/
+
 RUN find . -type f
 RUN du -s .
 EOF


### PR DESCRIPTION
Closes #1810

#### What has been done to verify that this works as intended?

- [x] tested locally
- [x] tested in CI

#### Why is this the best possible solution? Were any other approaches considered?

It's not ideal to include `.git` in the first place, but it's there.  This PR is a simple way to reasonably monitor build context contents without having to solve the issue of why `.git` has to be in the context in the first place.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect - just a CI check.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
