### PR TITLE
docker-compose: remove dangling volume: transfer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,7 +166,6 @@ services:
     restart: always
 volumes:
   secrets:
-  transfer:
   postgres14:
   enketo_redis_main:
   enketo_redis_cache:


### PR DESCRIPTION
Introduced in fe34e41c5d87744340384fe7fe4552182aa24e9d, it looks like this volume was never referenced.

Ref #1894

#### What has been done to verify that this works as intended?

Not so much.  But it was introduced in fe34e41c5d87744340384fe7fe4552182aa24e9d, and has never been referenced since.

#### Why is this the best possible solution? Were any other approaches considered?

The volume definition is misleading, because it implies it's related to `/data/transfer`, but it isn't.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.  Risk is especially low now as `/data/transfer` is no longer used (see #1894).

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

I don't think so.  But perhaps there are 3rd-party deployments out there which _do_ reference this volume.  They might be disappointed if it disappeared.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
