### PR TITLE
check-docker-context: use custom builder explicitly

### DIFF
--- a/test/check-docker-context.sh
+++ b/test/check-docker-context.sh
@@ -47,13 +47,13 @@ docker buildx rm docker_context_checker || true
 docker buildx create --name docker_context_checker \
     --driver-opt env.BUILDKIT_STEP_LOG_MAX_SIZE=-1 \
     --driver-opt env.BUILDKIT_STEP_LOG_MAX_SPEED=-1
-docker buildx use docker_context_checker
 
 log "Building docker image..."
 iidfile="$(mktemp)"
 (
 docker \
     buildx build --load \
+    --builder docker_context_checker \
     --iidfile "$iidfile" \
     --no-cache --progress plain --file - . 2>&1 <<EOF
 FROM busybox


### PR DESCRIPTION
Instead of changing the global builder default, just use the `docker_context_checker` custom builder for the specific job it was written for.

This is helpful for dev machines so that other docker jobs are not affected by this script.

#### What has been done to verify that this works as intended?

- [x] run locally, and then check current builder:

```sh
$ docker buildx inspect | head -n1
Name:          default
```

- [x] run in CI and checked it still uses expected builder, and passes: https://github.com/getodk/central/actions/runs/27556442626/job/81457048946?pr=1990

```
#0 building with "docker_context_checker" instance using docker-container driver
```

#### Why is this the best possible solution? Were any other approaches considered?

This is helpful for dev machines so that other docker jobs are not affected by this script.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect - just a test script.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced