### PR TITLE
build/nginx: reduce NodeJS max-old-space-size scope

### DIFF
--- a/files/prebuild/build-frontend.sh
+++ b/files/prebuild/build-frontend.sh
@@ -43,5 +43,5 @@ if [[ ${SKIP_FRONTEND_BUILD-} != "" ]]; then
   exit
 else
   npm clean-install --no-audit --fund=false --update-notifier=false
-  npm run build
+  NODE_OPTIONS="--max-old-space-size=4096" npm run build
 fi

--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update \
 COPY ./ ./
 RUN files/prebuild/write-version.sh
 
-ARG NODE_OPTIONS="--max-old-space-size=4096"
 ARG SKIP_FRONTEND_BUILD
 RUN files/prebuild/build-frontend.sh
 


### PR DESCRIPTION
Follow-up to https://github.com/getodk/central/pull/1976.

#### What has been done to verify that this works as intended?

Tested on dev.getodk.cloud and locally.

#### Why is this the best possible solution? Were any other approaches considered?

Memory already seems to be a worry, so making this extra allocation as specific as possible seems like a good safety measure.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Likely to make things slightly safer than in #1976, although memory use may still be a worry when rebuilding all services at once(?).

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced