### PR TITLE
build/nginx: reduce gc heap space allocation

### DIFF
--- a/files/prebuild/build-frontend.sh
+++ b/files/prebuild/build-frontend.sh
@@ -43,5 +43,5 @@ if [[ ${SKIP_FRONTEND_BUILD-} != "" ]]; then
   exit
 else
   npm clean-install --no-audit --fund=false --update-notifier=false
-  NODE_OPTIONS="--max-old-space-size=4096" npm run build
+  NODE_OPTIONS="--max-old-space-size=2048" npm run build
 fi

--- a/files/prebuild/build-frontend.sh
+++ b/files/prebuild/build-frontend.sh
@@ -43,5 +43,5 @@ if [[ ${SKIP_FRONTEND_BUILD-} != "" ]]; then
   exit
 else
   npm clean-install --no-audit --fund=false --update-notifier=false
-  npm run build
+  NODE_OPTIONS="--max-old-space-size=4096" npm run build
 fi

--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update \
 COPY ./ ./
 RUN files/prebuild/write-version.sh
 
-ARG NODE_OPTIONS="--max-old-space-size=4096"
 ARG SKIP_FRONTEND_BUILD
 RUN files/prebuild/build-frontend.sh
 


### PR DESCRIPTION
Reduces `max-old-space-size` allocation by 2GB (50%).

On dev.getodk.cloud this currently:

* fails with 1024
* passes with 1536

This suggests decreasing to 2048 is:

1. a good saving, and
2. fairly safe

#### What has been done to verify that this works as intended?

Tested locally and on dev.getodk.cloud.

#### Why is this the best possible solution? Were any other approaches considered?

On dev.getodk.cloud this currently:

* fails with 1024
* passes with 1536

This suggests decreasing to 2048 is:

1. a good saving, and
2. fairly safe

Memory is already a worry, so using less is probably good.  The current RAM is 2GB (~990 available) and swap is 4GB.  Using 4GB for node's gc heap may be risky.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Reduces the risk of OOM when rebuilding all services, but slightly increases it when rebuilding nginx??

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced