### PR TITLE
nginx/selfsign: use standard RSA key size

### DIFF
--- a/files/nginx/setup-odk.sh
+++ b/files/nginx/setup-odk.sh
@@ -30,7 +30,7 @@ fi
 SELFSIGN_PATH="/etc/selfsign/live/$DOMAIN"
 if [ "$SSL_TYPE" = "selfsign" ] && [ ! -s "$SELFSIGN_PATH/privkey.pem" ]; then
   mkdir -p "$SELFSIGN_PATH"
-  openssl req -x509 -newkey rsa:4086 \
+  openssl req -x509 -newkey rsa:4096 \
     -subj "/C=XX/ST=XXXX/L=XXXX/O=XXXX/CN=localhost" \
     -keyout "$SELFSIGN_PATH/privkey.pem" \
     -out "$SELFSIGN_PATH/fullchain.pem" \


### PR DESCRIPTION
The previous size of 4086 was likely copied from the README for `marvambass/nginx-ssl-secure` (https://github.com/MarvAmBass/docker-nginx-ssl-secure).  This was the original nginx base image used in this repo, introduced in 7cd48f70569149621eb07c86a05c68e0fa5c62ec.

Update: per https://github.com/MarvAmBass/docker-nginx-ssl-secure/issues/8, `4086` was a typo.

There's no obvious benefit to using a non-standard key size, and it's likely to cause confusion, and maybe affect security scoring.

For a comparison:

* https://www.google.com/search?q=%22openssl+req+-x509+-newkey+rsa%3A4086%22: 10 results
* https://www.google.com/search?q=%22openssl+req+-x509+-newkey+rsa%3A4096%22: 275 results

Closes https://github.com/getodk/central/issues/2034

#### What has been done to verify that this works as intended?

- [x] ci

#### Why is this the best possible solution? Were any other approaches considered?

There's no obvious benefit to using a non-standard key size, and it's likely to cause confusion, and maybe affect security scoring.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Unlikely to have an effect - new self-signing self-hosters shouldn't notice, existing users shouldn't have a new key generated.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] branched off and targeted the `next` branch OR only changed documentation/infrastructure (`master` is stable and used in production)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
