### PR TITLE
ci/build-push-image: fix nginx FRONTEND_BUILD_MODE error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,137 +1,18 @@
-name: Test, Build, Publish
+name: Test build-push-image
 
 on:
   push:
   pull_request:
-  workflow_dispatch:
-    inputs:
-      publish_image:
-        description: 'Publish image to registry?'
-        required: true
-        type: boolean
-        default: false
 
 jobs:
-  test-misc: # quick, simple checks
-    timeout-minutes: 2
-    runs-on: ubuntu-latest
-    steps:
-    - run: docker --version
-    - run: docker compose version
-    - uses: actions/checkout@v5
-    - run: ./test/check-submodules.sh
-    - run: ./test/test-with-pgenvblock.sh
-    - run: sudo apt-get install shellcheck
-    - run: ./test/check-scripts.sh
-    - run: ./test/check-for-large-files.sh
-    - run: ./test/check-dockerfiles.sh
-    - run: cd test && npm clean-install
-    - run: cd test && npm run lint
-    - run: cd test && npm run test:github-actions
-  test-envsub:
-    timeout-minutes: 2
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v5
-    - run: cd test/envsub && ./run-tests.sh
-  test-nginx:
-    timeout-minutes: 4
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v5
-    - uses: actions/setup-node@v5
-      with:
-        node-version-file: test/package.json
-    - run: cd test/nginx && npm clean-install
-    - run: cd test/nginx && ./setup-tests.sh
-    - run: cd test/nginx && npm run test:nginx:mocha
-    - run: cd test/nginx && ./lint-config.sh
-
-    - run: cd test/nginx && npx playwright install --with-deps chromium-headless-shell
-    - run: cd test/nginx && npm run test:nginx:playwright
-
-    - if: always()
-      run: cd test/nginx && docker compose -f nginx.test.docker-compose.yml logs --no-log-prefix nginx-ssl-selfsign
-    - if: always()
-      run: cd test/nginx && docker compose -f nginx.test.docker-compose.yml logs --no-log-prefix nginx-ssl-upstream
-    - if: always()
-      run: cd test/nginx && docker compose -f nginx.test.docker-compose.yml logs --no-log-prefix service
-    - if: always()
-      run: cd test/nginx && docker compose -f nginx.test.docker-compose.yml logs --no-log-prefix enketo
-    - if: always()
-      run: cd test/nginx && docker compose -f nginx.test.docker-compose.yml logs --no-log-prefix sentry-mock
-  test-secrets:
-    timeout-minutes: 2
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v5
-    - run: ./test/test-secrets.sh
-  test-service:
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v5
-      with:
-        submodules: true
-    - uses: actions/setup-node@v5
-      with:
-        node-version-file: test/package.json
-    - run: cd test/nginx && npm clean-install
-    - run: cd test/nginx && npm run test:service
-  test-images:
-    timeout-minutes: 10
-    needs:
-    - test-misc
-    - test-envsub
-    - test-nginx
-    - test-secrets
-    - test-service
-    runs-on: ubuntu-latest # TODO matrix to run on all expected versions?
-    steps:
-    - uses: actions/checkout@v5
-      with:
-        fetch-depth: 0
-        fetch-tags: true
-        submodules: recursive
-
-    - run: ./test/check-docker-context.sh --min-size 5000 --max-size 10000 --min-count 600 --max-count 700
-
-    - name: Extract FRONTEND_VERSION
-      run: |
-           touch .env
-           echo "FRONTEND_VERSION=$(
-             docker compose config --format json | jq -r .services.nginx.build.args.FRONTEND_VERSION
-           )" >> "$GITHUB_ENV"
-
-    - run: FRONTEND_BUILD_MODE=fetch ./test/test-images.sh
-
-    # Check out the current frontend version referenced by docker-compose, as it should build OK.
-    - run: |
-           git clone \
-               --depth 1 \
-               --branch "$FRONTEND_VERSION" \
-               https://github.com/getodk/central-frontend.git \
-               client
-    - run: FRONTEND_BUILD_MODE=source ./test/test-images.sh
-
-    - if: always()
-      run: docker compose logs
   build-push-image:
-    if: |
-      (github.event_name == 'workflow_dispatch' && inputs.publish_image == true) ||
-      (github.event_name != 'workflow_dispatch' && (
-        github.ref == 'refs/heads/master' ||
-        startsWith(github.ref, 'refs/tags/v')
-      ))
-    needs:
-    - test-images
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     strategy:
       matrix:
-        image: [nginx, service]
+        image: [nginx]
     env:
       REGISTRY: ghcr.io
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,11 +43,7 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
 
-    - id: get_frontend_version
-      run: |
-           echo "FRONTEND_VERSION=$(
-             docker compose config --format json | jq -r .services.nginx.build.args.FRONTEND_VERSION
-           )" >> "$GITHUB_OUTPUT"
+    - run: cat docker-compose.yml
 
     - name: Build and push ${{ matrix.image }} Docker image
       uses: docker/build-push-action@v7
@@ -58,6 +54,3 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         platforms: 'linux/amd64,linux/arm64'
-        build-args: |
-          FRONTEND_BUILD_MODE=fetch
-          FRONTEND_VERSION=${{ steps.get_frontend_version.outputs.FRONTEND_VERSION }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,12 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
 
+    - id: get_frontend_version
+      run: |
+           echo "FRONTEND_VERSION=$(
+             docker compose config --format json | jq -r .services.nginx.build.args.FRONTEND_VERSION
+           )" >> "$GITHUB_OUTPUT"
+
     - name: Build and push ${{ matrix.image }} Docker image
       uses: docker/build-push-action@v7
       with:
@@ -52,3 +58,6 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         platforms: 'linux/amd64,linux/arm64'
+        build-args: |
+          FRONTEND_BUILD_MODE=fetch
+          FRONTEND_VERSION=${{ steps.get_frontend_version.outputs.FRONTEND_VERSION }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,18 +1,137 @@
-name: Test build-push-image
+name: Test, Build, Publish
 
 on:
   push:
   pull_request:
+  workflow_dispatch:
+    inputs:
+      publish_image:
+        description: 'Publish image to registry?'
+        required: true
+        type: boolean
+        default: false
 
 jobs:
+  test-misc: # quick, simple checks
+    timeout-minutes: 2
+    runs-on: ubuntu-latest
+    steps:
+    - run: docker --version
+    - run: docker compose version
+    - uses: actions/checkout@v5
+    - run: ./test/check-submodules.sh
+    - run: ./test/test-with-pgenvblock.sh
+    - run: sudo apt-get install shellcheck
+    - run: ./test/check-scripts.sh
+    - run: ./test/check-for-large-files.sh
+    - run: ./test/check-dockerfiles.sh
+    - run: cd test && npm clean-install
+    - run: cd test && npm run lint
+    - run: cd test && npm run test:github-actions
+  test-envsub:
+    timeout-minutes: 2
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+    - run: cd test/envsub && ./run-tests.sh
+  test-nginx:
+    timeout-minutes: 4
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+    - uses: actions/setup-node@v5
+      with:
+        node-version-file: test/package.json
+    - run: cd test/nginx && npm clean-install
+    - run: cd test/nginx && ./setup-tests.sh
+    - run: cd test/nginx && npm run test:nginx:mocha
+    - run: cd test/nginx && ./lint-config.sh
+
+    - run: cd test/nginx && npx playwright install --with-deps chromium-headless-shell
+    - run: cd test/nginx && npm run test:nginx:playwright
+
+    - if: always()
+      run: cd test/nginx && docker compose -f nginx.test.docker-compose.yml logs --no-log-prefix nginx-ssl-selfsign
+    - if: always()
+      run: cd test/nginx && docker compose -f nginx.test.docker-compose.yml logs --no-log-prefix nginx-ssl-upstream
+    - if: always()
+      run: cd test/nginx && docker compose -f nginx.test.docker-compose.yml logs --no-log-prefix service
+    - if: always()
+      run: cd test/nginx && docker compose -f nginx.test.docker-compose.yml logs --no-log-prefix enketo
+    - if: always()
+      run: cd test/nginx && docker compose -f nginx.test.docker-compose.yml logs --no-log-prefix sentry-mock
+  test-secrets:
+    timeout-minutes: 2
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+    - run: ./test/test-secrets.sh
+  test-service:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+      with:
+        submodules: true
+    - uses: actions/setup-node@v5
+      with:
+        node-version-file: test/package.json
+    - run: cd test/nginx && npm clean-install
+    - run: cd test/nginx && npm run test:service
+  test-images:
+    timeout-minutes: 10
+    needs:
+    - test-misc
+    - test-envsub
+    - test-nginx
+    - test-secrets
+    - test-service
+    runs-on: ubuntu-latest # TODO matrix to run on all expected versions?
+    steps:
+    - uses: actions/checkout@v5
+      with:
+        fetch-depth: 0
+        fetch-tags: true
+        submodules: recursive
+
+    - run: ./test/check-docker-context.sh --min-size 5000 --max-size 10000 --min-count 600 --max-count 700
+
+    - name: Extract FRONTEND_VERSION
+      run: |
+           touch .env
+           echo "FRONTEND_VERSION=$(
+             docker compose config --format json | jq -r .services.nginx.build.args.FRONTEND_VERSION
+           )" >> "$GITHUB_ENV"
+
+    - run: FRONTEND_BUILD_MODE=fetch ./test/test-images.sh
+
+    # Check out the current frontend version referenced by docker-compose, as it should build OK.
+    - run: |
+           git clone \
+               --depth 1 \
+               --branch "$FRONTEND_VERSION" \
+               https://github.com/getodk/central-frontend.git \
+               client
+    - run: FRONTEND_BUILD_MODE=source ./test/test-images.sh
+
+    - if: always()
+      run: docker compose logs
   build-push-image:
+    if: |
+      (github.event_name == 'workflow_dispatch' && inputs.publish_image == true) ||
+      (github.event_name != 'workflow_dispatch' && (
+        github.ref == 'refs/heads/master' ||
+        startsWith(github.ref, 'refs/tags/v')
+      ))
+    needs:
+    - test-images
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     strategy:
       matrix:
-        image: [nginx]
+        image: [nginx, service]
     env:
       REGISTRY: ghcr.io
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,11 +43,12 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
 
-    - id: get_frontend_version
+    - name: Extract FRONTEND_VERSION
       run: |
+           touch .env
            echo "FRONTEND_VERSION=$(
              docker compose config --format json | jq -r .services.nginx.build.args.FRONTEND_VERSION
-           )" >> "$GITHUB_OUTPUT"
+           )" >> "$GITHUB_ENV"
 
     - name: Build and push ${{ matrix.image }} Docker image
       uses: docker/build-push-action@v7
@@ -60,4 +61,4 @@ jobs:
         platforms: 'linux/amd64,linux/arm64'
         build-args: |
           FRONTEND_BUILD_MODE=fetch
-          FRONTEND_VERSION=${{ steps.get_frontend_version.outputs.FRONTEND_VERSION }}
+          FRONTEND_VERSION=${{ env.FRONTEND_VERSION }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,11 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
 
-    - run: cat docker-compose.yml
+    - id: get_frontend_version
+      run: |
+           echo "FRONTEND_VERSION=$(
+             docker compose config --format json | jq -r .services.nginx.build.args.FRONTEND_VERSION
+           )" >> "$GITHUB_OUTPUT"
 
     - name: Build and push ${{ matrix.image }} Docker image
       uses: docker/build-push-action@v7
@@ -54,3 +58,6 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         platforms: 'linux/amd64,linux/arm64'
+        build-args: |
+          FRONTEND_BUILD_MODE=fetch
+          FRONTEND_VERSION=${{ steps.get_frontend_version.outputs.FRONTEND_VERSION }}


### PR DESCRIPTION
Closes #2043

#### What has been done to verify that this works as intended?

Ran it at: https://github.com/getodk/central/actions/runs/28703543011/job/85125477082

Still failing, but with a different error:

```
#39 [auth] getodk/central-nginx:pull,push token for ghcr.io
#39 DONE 0.0s
#38 exporting to image
#38 pushing layers 0.7s done
#38 ERROR: failed to push ghcr.io/getodk/central-nginx:pr-2042: denied: installation not allowed to Write organization package
------
 > exporting to image:
------
ERROR: failed to build: failed to solve: failed to push ghcr.io/getodk/central-nginx:pr-2042: denied: installation not allowed to Write organization package
```

I think this error is correct - this build was not run on a release git tag, so it's probably correct that it doesn't have permission to upload docker images for a release docker tag.

#### Why is this the best possible solution? Were any other approaches considered?

Likely a better long-term solution is to change actions from `docker/build-push-action` to `docker/bake-action`.  However, this close to release it's prudent to keep changes minimal by not changing action.  A ticket has been filed for changing action in the future at #2044. 

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No impact.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.