### PR TITLE
test/nginx/request(): use WHATWG Responses

### DIFF
--- a/test/nginx/src/mocha/mocha.setup.js
+++ b/test/nginx/src/mocha/mocha.setup.js
@@ -1,9 +1,14 @@
 import http from 'node:http';
 import https from 'node:https';
 
+const log = (...args) => console.log('[mocha-setup]', ...args);
+
 export const mochaHooks = {
   afterAll() {
+    log('Cleaning up HTTP(S) Response objects whose bodies have not been read...');
     http.globalAgent.destroy();
     https.globalAgent.destroy();
+
+    log('Cleanup complete.');
   },
 };

--- a/test/nginx/src/mocha/mocha.setup.js
+++ b/test/nginx/src/mocha/mocha.setup.js
@@ -1,0 +1,9 @@
+import http from 'node:http';
+import https from 'node:https';
+
+export const mochaHooks = {
+  afterAll() {
+    http.globalAgent.destroy();
+    https.globalAgent.destroy();
+  },
+};

--- a/test/nginx/src/mocha/mocha.setup.js
+++ b/test/nginx/src/mocha/mocha.setup.js
@@ -4,11 +4,13 @@ const https = require('node:https');
 const log = (...args) => console.log('[mocha-setup]', ...args);
 
 module.exports = {
-  afterAll() {
-    log('Cleaning up HTTP(S) Response objects whose bodies have not been read...');
-    http.globalAgent.destroy();
-    https.globalAgent.destroy();
+  mochaHooks: {
+    afterAll() {
+      log('Cleaning up HTTP(S) Response objects whose bodies have not been read...');
+      http.globalAgent.destroy();
+      https.globalAgent.destroy();
 
-    log('Cleanup complete.');
+      log('Cleanup complete.');
+    },
   },
 };

--- a/test/nginx/src/mocha/mocha.setup.js
+++ b/test/nginx/src/mocha/mocha.setup.js
@@ -1,9 +1,9 @@
-import http from 'node:http';
-import https from 'node:https';
+const http = require('node:http');
+const https = require('node:https');
 
 const log = (...args) => console.log('[mocha-setup]', ...args);
 
-export const mochaHooks = {
+module.exports = {
   afterAll() {
     log('Cleaning up HTTP(S) Response objects whose bodies have not been read...');
     http.globalAgent.destroy();

--- a/test/nginx/src/mocha/request.js
+++ b/test/nginx/src/mocha/request.js
@@ -1,5 +1,4 @@
 const { isIPv6 } = require('node:net');
-const { Readable } = require('node:stream');
 
 module.exports = request;
 
@@ -16,29 +15,11 @@ function request(url, { body, ...options }={}) {
       const req = getProtocolImplFrom(url).request({ ...options, ...preserve(url) }, res => {
         res.on('error', reject);
 
-        const body = new Readable({ read:() => {} });
-        res.on('error', err => body.destroy(err));
-        res.on('data', data => body.push(data));
-        res.on('end', () => body.push(null));
-
-        const text = () => new Promise((resolve, reject) => {
-          const chunks = [];
-          body.on('error', reject);
-          body.on('data', data => chunks.push(data));
-          body.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
-        });
-
-        const status = res.statusCode;
-
-        resolve({
-          status,
-          ok: status >= 200 && status < 300,
-          statusText: res.statusText,
-          body,
-          text,
-          json: async () => JSON.parse(await text()),
+        resolve(new Response(res, {
+          status: res.statusCode,
+          statusText: res.statusMessage,
           headers: new Headers(res.headers),
-        });
+        }));
       });
       req.on('error', reject);
       if(body !== undefined) req.write(body);

--- a/test/package.json
+++ b/test/package.json
@@ -4,7 +4,7 @@
     "lint": "ESLINT_USE_FLAT_CONFIG=false npx eslint --cache .",
     "test:github-actions": "mocha ./github-actions.spec.js",
     "test:nginx": "npm run test:nginx:mocha && npm run test:nginx:playwright",
-    "test:nginx:mocha": "NODE_TLS_REJECT_UNAUTHORIZED=0 mocha ./nginx/src/mocha",
+    "test:nginx:mocha": "NODE_TLS_REJECT_UNAUTHORIZED=0 mocha './nginx/src/mocha/**/*.spec.js' --require ./nginx/src/mocha/mocha.setup.js",
     "test:nginx:playwright": "NODE_TLS_REJECT_UNAUTHORIZED=0 playwright test",
     "test:service": "mocha ./service.spec.js",
     "test": "npm run lint && npm run test:github-actions && npm run test:nginx && npm run test:service"


### PR DESCRIPTION
Simplifies test `request()` implementation to use standard `Response` classes.  The `request()` function aims to be as similar to `fetch()` as possible, while allowing for non-standard behaviour necessary for tests.  Not using `Response` was an oversight in the initial implementation.

#### What has been done to verify that this works as intended?

- [x] ci (existing test suite)

#### Why is this the best possible solution? Were any other approaches considered?

Simplifies code.  If response handing _needs_ to diverge from `Response` in future, tests can be added to `test/nginx/src/mocha/request.spec.js` to reflect that.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No change - just test code.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.