### PR TITLE
test/nginx: prefix test-specific server endpoints

### DIFF
--- a/test/nginx/mock-http-server/index.js
+++ b/test/nginx/mock-http-server/index.js
@@ -25,9 +25,9 @@ app.use('/-/', (req, res, next) => {
   next();
 });
 
-app.get('/health',      (req, res) => res.send('OK'));
-app.get('/request-log', (req, res) => res.json(requests));
-app.get('/reset',       (req, res) => {
+app.get('/__mock_http_server/health',      (req, res) => res.send('OK'));
+app.get('/__mock_http_server/request-log', (req, res) => res.json(requests));
+app.get('/__mock_http_server/reset',       (req, res) => {
   requests.length = 0;
   res.json('OK');
 });

--- a/test/nginx/mock-sentry/index.js
+++ b/test/nginx/mock-sentry/index.js
@@ -27,8 +27,8 @@ app.use(express.json({
     'application/reports+json', // https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/report-to#violation_report_syntax
   ],
 }));
-app.get('/event-log', (req, res) => res.json(events));
-app.get('/reset',       (req, res) => {
+app.get('/__mock_sentry/event-log', (req, res) => res.json(events));
+app.get('/__mock_sentry/reset',       (req, res) => {
   events.length = 0;
   res.json('OK');
 });

--- a/test/nginx/setup-tests.sh
+++ b/test/nginx/setup-tests.sh
@@ -31,9 +31,9 @@ log "Starting test services..."
 docker_compose up --build --detach
 
 log "Waiting for mock backend..."
-wait_for_http_response 5 localhost:8383/health 200
+wait_for_http_response 5 localhost:8383/__mock_http_server/health 200
 log "Waiting for mock enketo..."
-wait_for_http_response 5 localhost:8005/health 200
+wait_for_http_response 5 localhost:8005/__mock_http_server/health 200
 log "Waiting for nginx..."
 wait_for_http_response 5 localhost:9000 421
 

--- a/test/nginx/src/lib.js
+++ b/test/nginx/src/lib.js
@@ -13,7 +13,7 @@ module.exports = {
 };
 
 async function assertSentryReceived(...expectedRequests) {
-  const { status, body } = await requestSentryMock({ path:'/event-log' });
+  const { status, body } = await requestSentryMock({ path:'/__mock_sentry/event-log' });
   assert.equal(status, 200);
 
   const actual = JSON.parse(body);
@@ -27,7 +27,7 @@ async function assertSentryReceived(...expectedRequests) {
 }
 
 async function resetSentryMock() {
-  const res = await requestSentryMock({ path:'/reset' });
+  const res = await requestSentryMock({ path:'/__mock_sentry/reset' });
   assert.equal(res.status, 200);
 }
 

--- a/test/nginx/src/mocha/nginx.spec.js
+++ b/test/nginx/src/mocha/nginx.spec.js
@@ -1162,7 +1162,7 @@ function assertBackendReceived(...expectedRequests) {
 }
 
 async function assertMockHttpReceived(port, expectedRequests) {
-  const res = await request(`http://localhost:${port}/request-log`);
+  const res = await request(`http://localhost:${port}/__mock_http_server/request-log`);
   assert.isTrue(res.ok);
   assert.deepEqual(expectedRequests, await res.json());
 }
@@ -1176,7 +1176,7 @@ function resetBackendMock() {
 }
 
 async function resetMock(port) {
-  const res = await request(`http://localhost:${port}/reset`);
+  const res = await request(`http://localhost:${port}/__mock_http_server/reset`);
   assert.isTrue(res.ok);
 }
 


### PR DESCRIPTION
Help reason about routing by clearly delineating test-specific paths from those which are shadowing real paths.

#### What has been done to verify that this works as intended?

- [x] ci

#### Why is this the best possible solution? Were any other approaches considered?

This is helpful.  Also this allows more guards (e.g. path-specific middleware) to be added later to ensure correct use of these APIs.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No change - just test code.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.