### PR TITLE
ci/build-push-image: fix nginx FRONTEND_BUILD_MODE error (#2042)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,6 +162,13 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
 
+    - name: Extract FRONTEND_VERSION
+      run: |
+           touch .env
+           echo "FRONTEND_VERSION=$(
+             docker compose config --format json | jq -r .services.nginx.build.args.FRONTEND_VERSION
+           )" >> "$GITHUB_ENV"
+
     - name: Build and push ${{ matrix.image }} Docker image
       uses: docker/build-push-action@v7
       with:
@@ -171,3 +178,6 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         platforms: 'linux/amd64,linux/arm64'
+        build-args: |
+          FRONTEND_BUILD_MODE=fetch
+          FRONTEND_VERSION=${{ env.FRONTEND_VERSION }}


### PR DESCRIPTION
Fixes error seen on release:

```
> [linux/amd64 intermediate 4/5] RUN files/prebuild/write-version.sh:
0.073 files/prebuild/write-version.sh: line 26: FRONTEND_BUILD_MODE: unbound variable
```

Merged to master in https://github.com/getodk/central/pull/2042

#### What has been done to verify that this works as intended?

See https://github.com/getodk/central/pull/2042

#### Why is this the best possible solution? Were any other approaches considered?

See https://github.com/getodk/central/pull/2042

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

See https://github.com/getodk/central/pull/2042

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

See https://github.com/getodk/central/pull/2042