### PR TITLE
ci: error if `FRONTEND_VERSION` not found

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,6 +162,13 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
 
+    - name: Extract FRONTEND_VERSION
+      run: |
+           touch .env
+           echo "FRONTEND_VERSION=$(
+             docker compose config --format json | jq -r .services.nginx.build.args.FRONTEND_VERSION
+           )" >> "$GITHUB_ENV"
+
     - name: Build and push ${{ matrix.image }} Docker image
       uses: docker/build-push-action@v7
       with:
@@ -171,3 +178,6 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         platforms: 'linux/amd64,linux/arm64'
+        build-args: |
+          FRONTEND_BUILD_MODE=fetch
+          FRONTEND_VERSION=${{ env.FRONTEND_VERSION }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,7 +100,7 @@ jobs:
       run: |
            touch .env
            echo "FRONTEND_VERSION=$(
-             docker compose config --format json | jq -r .services.nginx.build.args.FRONTEND_VERSION
+             docker compose config --format json | jq -er .services.nginx.build.args.FRONTEND_VERSION
            )" >> "$GITHUB_ENV"
 
     - run: FRONTEND_BUILD_MODE=fetch ./test/test-images.sh
@@ -166,7 +166,7 @@ jobs:
       run: |
            touch .env
            echo "FRONTEND_VERSION=$(
-             docker compose config --format json | jq -r .services.nginx.build.args.FRONTEND_VERSION
+             docker compose config --format json | jq -er .services.nginx.build.args.FRONTEND_VERSION
            )" >> "$GITHUB_ENV"
 
     - name: Build and push ${{ matrix.image }} Docker image

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,13 +96,7 @@ jobs:
 
     - run: ./test/check-docker-context.sh --min-size 5000 --max-size 10000 --min-count 600 --max-count 700
 
-    - name: Extract FRONTEND_VERSION
-      run: |
-           touch .env
-           echo "FRONTEND_VERSION=$(
-             docker compose config --format json | jq -er .services.nginx.build.args.FRONTEND_VERSION_DELIBERATELY_INCORRECT
-           )" >> "$GITHUB_ENV"
-
+    - run: ./files/ci/extract-frontend-version.sh
     - run: FRONTEND_BUILD_MODE=fetch ./test/test-images.sh
 
     # Check out the current frontend version referenced by docker-compose, as it should build OK.
@@ -162,12 +156,7 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
 
-    - name: Extract FRONTEND_VERSION
-      run: |
-           touch .env
-           echo "FRONTEND_VERSION=$(
-             docker compose config --format json | jq -er .services.nginx.build.args.FRONTEND_VERSION
-           )" >> "$GITHUB_ENV"
+    - run: ./files/ci/extract-frontend-version.sh
 
     - name: Build and push ${{ matrix.image }} Docker image
       uses: docker/build-push-action@v7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,7 +100,7 @@ jobs:
       run: |
            touch .env
            echo "FRONTEND_VERSION=$(
-             docker compose config --format json | jq -er .services.nginx.build.args.FRONTEND_VERSION
+             docker compose config --format json | jq -er .services.nginx.build.args.FRONTEND_VERSION_DELIBERATELY_INCORRECT
            )" >> "$GITHUB_ENV"
 
     - run: FRONTEND_BUILD_MODE=fetch ./test/test-images.sh

--- a/files/ci/extract-frontend-version.sh
+++ b/files/ci/extract-frontend-version.sh
@@ -8,7 +8,7 @@ log "Ensuring .env exists for docker compose..."
 touch .env
 
 log "Reading FRONTEND_VERSION from docker-compose.yml..."
-if ! frontendVersion="$(docker compose config --format json | jq -er .services.nginx.build.args.FRONTEND_VERSION_DELIBERATELY_INCORRECT)"; then
+if ! frontendVersion="$(docker compose config --format json | jq -er .services.nginx.build.args.FRONTEND_VERSION)"; then
   log "!!!"
   log "!!! Failed to read FRONTEND_VERSION from docker-compose.yml (got: '$frontendVersion')."
   log "!!!"

--- a/files/ci/extract-frontend-version.sh
+++ b/files/ci/extract-frontend-version.sh
@@ -9,9 +9,9 @@ touch .env
 
 log "Reading FRONTEND_VERSION from docker-compose.yml..."
 if ! frontendVersion="$(docker compose config --format json | jq -er .services.nginx.build.args.FRONTEND_VERSION_DELIBERATELY_INCORRECT)"; then
-	log "!!!"
-	log "!!! Failed to read FRONTEND_VERSION from docker-compose.yml (got: '$frontendVersion')."
-	log "!!!"
+  log "!!!"
+  log "!!! Failed to read FRONTEND_VERSION from docker-compose.yml (got: '$frontendVersion')."
+  log "!!!"
   exit 1
 fi
 

--- a/files/ci/extract-frontend-version.sh
+++ b/files/ci/extract-frontend-version.sh
@@ -2,13 +2,18 @@
 set -o pipefail
 shopt -s inherit_errexit
 
-log() { echo >&2 "[$(basname "$0")] $*"; }
+log() { echo >&2 "[$(basename "$0")] $*"; }
 
-log "Making sure .env exists..."
+log "Ensuring .env exists for docker compose..."
 touch .env
 
 log "Reading FRONTEND_VERSION from docker-compose.yml..."
-frontendVersion="$(docker compose config --format json | jq -er .services.nginx.build.args.FRONTEND_VERSION_DELIBERATELY_INCORRECT)"
+if ! frontendVersion="$(docker compose config --format json | jq -er .services.nginx.build.args.FRONTEND_VERSION_DELIBERATELY_INCORRECT)"; then
+	log "!!!"
+	log "!!! Failed to read FRONTEND_VERSION from docker-compose.yml (got: '$frontendVersion')."
+	log "!!!"
+  exit 1
+fi
 
 log "Writing FRONTEND_VERSION to GITHUB_ENV file ($GITHUB_ENV)..."
 echo "FRONTEND_VERSION=$FRONTEND_VERSION" >> "$GITHUB_ENV"

--- a/files/ci/extract-frontend-version.sh
+++ b/files/ci/extract-frontend-version.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -eu
+set -o pipefail
+shopt -s inherit_errexit
+
+log() { echo >&2 "[$(basname "$0")] $*"; }
+
+log "Making sure .env exists..."
+touch .env
+
+log "Reading FRONTEND_VERSION from docker-compose.yml..."
+frontendVersion="$(docker compose config --format json | jq -er .services.nginx.build.args.FRONTEND_VERSION_DELIBERATELY_INCORRECT)"
+
+log "Writing FRONTEND_VERSION to GITHUB_ENV file ($GITHUB_ENV)..."
+echo "FRONTEND_VERSION=$FRONTEND_VERSION" >> "$GITHUB_ENV"
+
+log "Completed OK."

--- a/files/ci/extract-frontend-version.sh
+++ b/files/ci/extract-frontend-version.sh
@@ -16,6 +16,6 @@ if ! frontendVersion="$(docker compose config --format json | jq -er .services.n
 fi
 
 log "Writing FRONTEND_VERSION to GITHUB_ENV file ($GITHUB_ENV)..."
-echo "FRONTEND_VERSION=$FRONTEND_VERSION" >> "$GITHUB_ENV"
+echo "FRONTEND_VERSION=$frontendVersion" >> "$GITHUB_ENV"
 
 log "Completed OK."


### PR DESCRIPTION
Re https://github.com/getodk/central/pull/2042#discussion_r3530680355

Adding `-e` isn't enough to cause a helpful failure when `FRONTEND_VERSION` is missing from `docker-compose.yml` because:

1. it doesn't fail, despite `bash -e`, because the `jq` command runs inside the `echo` call, which succeeds, and
2. if the intention is for the failure to be easy to understand, `jq -e` won't help on its own

#### What has been done to verify that this works as intended?

- [x] checked behaviour locally
- [x] tested first invocation
- [ ] tested second invocation

#### Why is this the best possible solution? Were any other approaches considered?

Here's what failure looks like now:

```
[extract-frontend-version.sh] Ensuring .env exists for docker compose...
[extract-frontend-version.sh] Reading FRONTEND_VERSION from docker-compose.yml...
time="2026-07-07T03:33:30Z" level=warning msg="The \"DOMAIN\" variable is not set. Defaulting to a blank string."
time="2026-07-07T03:33:30Z" level=warning msg="The \"SYSADMIN_EMAIL\" variable is not set. Defaulting to a blank string."
time="2026-07-07T03:33:30Z" level=warning msg="The \"DOMAIN\" variable is not set. Defaulting to a blank string."
time="2026-07-07T03:33:30Z" level=warning msg="The \"DOMAIN\" variable is not set. Defaulting to a blank string."
time="2026-07-07T03:33:30Z" level=warning msg="The \"SYSADMIN_EMAIL\" variable is not set. Defaulting to a blank string."
time="2026-07-07T03:33:30Z" level=warning msg="The \"DOMAIN\" variable is not set. Defaulting to a blank string."
time="2026-07-07T03:33:30Z" level=warning msg="The \"DOMAIN\" variable is not set. Defaulting to a blank string."
time="2026-07-07T03:33:30Z" level=warning msg="The \"SYSADMIN_EMAIL\" variable is not set. Defaulting to a blank string."
[extract-frontend-version.sh] !!!
[extract-frontend-version.sh] !!! Failed to read FRONTEND_VERSION from docker-compose.yml (got: 'null').
[extract-frontend-version.sh] !!!
```

And success:

<kbd>
<img width="595" height="432" alt="Screenshot_2026-07-07_07-26-50" src="https://github.com/user-attachments/assets/8166cb7b-c824-4f9c-b57f-876dc26aac89" />

</kbd>


#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No impact.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.