### PR TITLE
service/start-odk: expose postgres connection errors & allow failure

### DIFF
--- a/files/service/scripts/start-odk.sh
+++ b/files/service/scripts/start-odk.sh
@@ -43,7 +43,10 @@ SENTRY_TAGS="{ \"version.central\": \"$(cat sentry-versions/central)\", \"versio
 export SENTRY_TAGS
 
 echo "waiting for PostgreSQL to become connectable to..."
-while ! (psql --no-password --quiet --command "" > /dev/null 2>&1 || (echo "sleeping 1 second waiting for a database connection"; false)); do sleep 1; done
+while ! pg_isready --quiet; do
+  echo "sleeping 1 second waiting for a database connection"
+  sleep 1
+done
 
 echo "running migrations.."
 node ./lib/bin/run-migrations

--- a/files/service/scripts/start-odk.sh
+++ b/files/service/scripts/start-odk.sh
@@ -43,10 +43,18 @@ SENTRY_TAGS="{ \"version.central\": \"$(cat sentry-versions/central)\", \"versio
 export SENTRY_TAGS
 
 echo "waiting for PostgreSQL to become connectable to..."
-while ! pg_isready --quiet; do
+maxRetries=10
+retries=$maxRetries
+while ! pg_isready --timeout 10 && [[ $retries -gt 0 ]]; do
   echo "sleeping 1 second waiting for a database connection"
+  retries=$((retries-1))
   sleep 1
 done
+if [[ "$retries" = 0 ]]; then
+  echo "Postgres not available after $maxRetries attempts."
+  sleep 1 # reduce thrashing
+  exit 1
+fi
 
 echo "running migrations.."
 node ./lib/bin/run-migrations

--- a/files/service/scripts/start-odk.sh
+++ b/files/service/scripts/start-odk.sh
@@ -43,16 +43,16 @@ SENTRY_TAGS="{ \"version.central\": \"$(cat sentry-versions/central)\", \"versio
 export SENTRY_TAGS
 
 echo "waiting for PostgreSQL to become connectable to..."
-maxRetries=15
-retries=$maxRetries
+maxTries=15
+retries=$((maxTries-1))
 while ! pg_isready; do
-  echo "sleeping 1 second waiting for a database connection"
-  retries=$((retries-1))
-  sleep 1
-  if [[ "$retries" -lt 0 ]]; then
-    echo "PostgreSQL not available after $maxRetries attempts."
+  if [[ "$retries" = 0 ]]; then
+    echo "PostgreSQL not available after $maxTries attempts."
     exit 1
   fi
+  echo "PostgreSQL not yet available; sleeping 1 second..."
+  sleep 1
+  retries=$((retries-1))
 done
 
 echo "running migrations.."

--- a/files/service/scripts/start-odk.sh
+++ b/files/service/scripts/start-odk.sh
@@ -43,13 +43,13 @@ SENTRY_TAGS="{ \"version.central\": \"$(cat sentry-versions/central)\", \"versio
 export SENTRY_TAGS
 
 echo "waiting for PostgreSQL to become connectable to..."
-maxRetries=10
+maxRetries=15
 retries=$maxRetries
-while ! pg_isready --timeout 10; do
+while ! pg_isready; do
   echo "sleeping 1 second waiting for a database connection"
   retries=$((retries-1))
   sleep 1
-  if [[ "$retries" = 0 ]]; then
+  if [[ "$retries" -lt 0 ]]; then
     echo "PostgreSQL not available after $maxRetries attempts."
     exit 1
   fi

--- a/files/service/scripts/start-odk.sh
+++ b/files/service/scripts/start-odk.sh
@@ -50,7 +50,7 @@ while ! pg_isready --timeout 10; do
   retries=$((retries-1))
   sleep 1
   if [[ "$retries" = 0 ]]; then
-    echo "Postgres not available after $maxRetries attempts."
+    echo "PostgreSQL not available after $maxRetries attempts."
     exit 1
   fi
 done

--- a/files/service/scripts/start-odk.sh
+++ b/files/service/scripts/start-odk.sh
@@ -45,16 +45,15 @@ export SENTRY_TAGS
 echo "waiting for PostgreSQL to become connectable to..."
 maxRetries=10
 retries=$maxRetries
-while ! pg_isready --timeout 10 && [[ $retries -gt 0 ]]; do
+while ! pg_isready --timeout 10; do
   echo "sleeping 1 second waiting for a database connection"
   retries=$((retries-1))
   sleep 1
+  if [[ "$retries" = 0 ]]; then
+    echo "Postgres not available after $maxRetries attempts."
+    exit 1
+  fi
 done
-if [[ "$retries" = 0 ]]; then
-  echo "Postgres not available after $maxRetries attempts."
-  sleep 1 # reduce thrashing
-  exit 1
-fi
 
 echo "running migrations.."
 node ./lib/bin/run-migrations


### PR DESCRIPTION
* replace `psql` with `pg_isready`
* don't suppress useful output

#### What has been done to verify that this works as intended?

##### ☑️ if `pg_isready` is missing, it fails with:

```
service-1   | waiting for PostgreSQL to become connectable to...
service-1   | ./start-odk.sh: line 48: pg_isreadyxxx: command not found
service-1   | sleeping 1 second waiting for a database connection
service-1   | ./start-odk.sh: line 48: pg_isreadyxxx: command not found
service-1   | sleeping 1 second waiting for a database connection
service-1   | ./start-odk.sh: line 48: pg_isreadyxxx: command not found
service-1   | sleeping 1 second waiting for a database connection
service-1   | ./start-odk.sh: line 48: pg_isreadyxxx: command not found
service-1   | sleeping 1 second waiting for a database connection
service-1   | ./start-odk.sh: line 48: pg_isreadyxxx: command not found
service-1   | sleeping 1 second waiting for a database connection
service-1   | ./start-odk.sh: line 48: pg_isreadyxxx: command not found
service-1   | sleeping 1 second waiting for a database connection
service-1   | ./start-odk.sh: line 48: pg_isreadyxxx: command not found
service-1   | sleeping 1 second waiting for a database connection
service-1   | ./start-odk.sh: line 48: pg_isreadyxxx: command not found
service-1   | sleeping 1 second waiting for a database connection
service-1   | ./start-odk.sh: line 48: pg_isreadyxxx: command not found
service-1   | sleeping 1 second waiting for a database connection
service-1   | ./start-odk.sh: line 48: pg_isreadyxxx: command not found
service-1   | sleeping 1 second waiting for a database connection
service-1   | ./start-odk.sh: line 48: pg_isreadyxxx: command not found
service-1   | Postgres not available after 10 attempts.
service-1 exited with code 1 (restarting)
```

##### ☑️ If host is incorrect if fails with:

```
service-1  | waiting for PostgreSQL to become connectable to...
service-1  | postgres.bad.example.test:5432:5432 - no response
service-1  | sleeping 1 second waiting for a database connection
service-1  | postgres.bad.example.test:5432:5432 - no response
service-1  | sleeping 1 second waiting for a database connection
service-1  | postgres.bad.example.test:5432:5432 - no response
service-1  | sleeping 1 second waiting for a database connection
service-1  | postgres.bad.example.test:5432:5432 - no response
service-1  | sleeping 1 second waiting for a database connection
service-1  | postgres.bad.example.test:5432:5432 - no response
service-1  | sleeping 1 second waiting for a database connection
service-1  | postgres.bad.example.test:5432:5432 - no response
service-1  | sleeping 1 second waiting for a database connection
service-1  | postgres.bad.example.test:5432:5432 - no response
service-1  | sleeping 1 second waiting for a database connection
service-1  | postgres.bad.example.test:5432:5432 - no response
service-1  | sleeping 1 second waiting for a database connection
service-1  | postgres.bad.example.test:5432:5432 - no response
service-1  | sleeping 1 second waiting for a database connection
service-1  | postgres.bad.example.test:5432:5432 - no response
service-1  | sleeping 1 second waiting for a database connection
service-1  | Postgres not available after 10 attempts.
service-1 exited with code 1 (restarting)
```

##### ☑️ If database name is incorrect if fails with:

```
service-1  | waiting for PostgreSQL to become connectable to...
service-1  | postgres14:5432 - accepting connections
service-1  | running migrations..
service-1  | Error: database "bad_db_name" does not exist
service-1 exited with code 1 (restarting)
```

##### ☑️ If username is incorrect if fails with:

```
service-1  | waiting for PostgreSQL to become connectable to...
service-1  | postgres14:5432 - accepting connections
service-1  | running migrations..
service-1  | Error: password authentication failed for user "not_a_real_user"
service-1 exited with code 1 (restarting)
```

##### ☑️ If password is incorrect if fails with:

```
service-1  | waiting for PostgreSQL to become connectable to...
service-1  | postgres14:5432 - accepting connections
service-1  | running migrations..
service-1  | Error: password authentication failed for user "odk"
```

#### Why is this the best possible solution? Were any other approaches considered?

* specifically written for this job
* provided by postgres team
* idiomatic

See: https://www.postgresql.org/docs/current/app-pg-isready.html

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

Low chance of regression, but perhaps the current approach is doing something non-obvious.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.