### PR TITLE
ci: fix publish_images var name & label

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,8 +5,8 @@ on:
   pull_request:
   workflow_dispatch:
     inputs:
-      publish_image:
-        description: 'Publish image to registry?'
+      publish_images:
+        description: 'Publish images to registry?'
         required: true
         type: boolean
         default: false
@@ -118,7 +118,7 @@ jobs:
       run: docker compose logs
   build-push-image:
     if: |
-      (github.event_name == 'workflow_dispatch' && inputs.publish_image == true) ||
+      (github.event_name == 'workflow_dispatch' && inputs.publish_images == true) ||
       (github.event_name != 'workflow_dispatch' && (
         github.ref == 'refs/heads/master' ||
         startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
Selecting this option publishes more than 1 image.

#### What has been done to verify that this works as intended?

Nothing yet.

#### Why is this the best possible solution? Were any other approaches considered?

It's a little confusing if you're expecting to publish multiple images for the option to be singular.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No impact.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.