### PR TITLE
service/start-odk: fix DB_SSL check in non docker-compose envs

### DIFF
--- a/files/service/scripts/start-odk.sh
+++ b/files/service/scripts/start-odk.sh
@@ -3,7 +3,7 @@ set -o pipefail
 shopt -s inherit_errexit
 
 # Check for illegal DB_SSL environment variable.
-if ! [[ "${DB_SSL-}" = null ]]; then
+if [[ -v DB_SSL ]] && ! [[ "$DB_SSL" = null ]]; then
   echo "!!!"
   echo "!!! You have the DB_SSL variable defined (in your .env file, probably)."
   echo "!!! This variable is no longer supported from Central 2026.1 onwards."

--- a/files/service/scripts/start-odk.sh
+++ b/files/service/scripts/start-odk.sh
@@ -3,7 +3,7 @@ set -o pipefail
 shopt -s inherit_errexit
 
 # Check for illegal DB_SSL environment variable.
-if [[ -v DB_SSL ]] && ! [[ "$DB_SSL" = null ]]; then
+if [[ -v DB_SSL ]] && ! [[ "$DB_SSL" = "null" ]]; then
   echo "!!!"
   echo "!!! You have the DB_SSL variable defined (in your .env file, probably)."
   echo "!!! This variable is no longer supported from Central 2026.1 onwards."

--- a/test/package.json
+++ b/test/package.json
@@ -6,7 +6,7 @@
     "test:nginx": "npm run test:nginx:mocha && npm run test:nginx:playwright",
     "test:nginx:mocha": "NODE_TLS_REJECT_UNAUTHORIZED=0 mocha './nginx/src/mocha/**/*.spec.js' --require ./nginx/src/mocha/mocha.setup.js",
     "test:nginx:playwright": "NODE_TLS_REJECT_UNAUTHORIZED=0 playwright test",
-    "test:service": "mocha ./service.spec.js",
+    "test:service": "mocha ./service/service.spec.js",
     "test": "npm run lint && npm run test:github-actions && npm run test:nginx && npm run test:service"
   },
   "dependencies": {

--- a/test/service/no-db-ssl.docker-compose.yml
+++ b/test/service/no-db-ssl.docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  service:
+    environment:
+      # Setting this to `null` in YAML actually UNSETS the variable, in
+      # contrast to the string "null", which is set in the parent YAML.
+      DB_SSL: null

--- a/test/service/service.spec.js
+++ b/test/service/service.spec.js
@@ -29,7 +29,7 @@ describe('service image', () => {
     const runService = (...args) => new Promise(resolve => {
       const stdcombi = [];
 
-      const process = spawn('docker', [ 'compose', 'run', ...args, 'service' ], { cwd:'..' });
+      const process = spawn('docker', [ 'compose', ...args, 'service' ], { cwd:'..' });
 
       const appendOutput = data => {
         const str = data.toString();
@@ -73,7 +73,7 @@ describe('service image', () => {
         this.timeout(10_000);
 
         // when
-        const { stdcombi } = await runService('--env', `DB_SSL=${badVal}`);
+        const { stdcombi } = await runService('run', '--env', `DB_SSL=${badVal}`);
 
         // then
         assertIncludes(stdcombi, unresolvedIssue);
@@ -88,7 +88,7 @@ describe('service image', () => {
         this.timeout(10_000);
 
         // when
-        const { stdcombi } = await runService('--env', `DB_SSL=${goodVal}`);
+        const { stdcombi } = await runService('run', '--env', `DB_SSL=${goodVal}`);
 
         // then
         assertIncludes(stdcombi, generatingServiceConfig);
@@ -100,7 +100,22 @@ describe('service image', () => {
       this.timeout(10_000);
 
       // when
-      const { stdcombi } = await runService();
+      const { stdcombi } = await runService('run');
+
+      // then
+      assertIncludes(stdcombi, generatingServiceConfig);
+      assertNotIncludes(stdcombi, unresolvedIssue);
+    });
+
+    it('should start OK if DB_SSL is not set at all', async function() {
+      this.timeout(10_000);
+
+      // when
+      const { stdcombi } = await runService(
+        '--file', 'docker-compose.yml',
+        '--file', './test/service/no-db-ssl.docker-compose.yml',
+        'run',
+      );
 
       // then
       assertIncludes(stdcombi, generatingServiceConfig);


### PR DESCRIPTION
Closes #2063

#### What has been done to verify that this works as intended?

New test.

#### Why is this the best possible solution? Were any other approaches considered?

It doesn't change behaviour when using docker compose, but should fix the problem for environments where it's really possible to not have any value for `DB_SSL`.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

Fixes a bug.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.