### PR TITLE
test/nginx: make SENTRY_DSN_FRONTEND value realistic

### DIFF
--- a/test/nginx/lib.docker-compose.yml
+++ b/test/nginx/lib.docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - SENTRY_ORG_SUBDOMAIN=o-fake-dsn
       - SENTRY_PROJECT=example-sentry-project
       - OIDC_ENABLED=false
-      - SENTRY_DSN_FRONTEND=https://fake-dsn.fake-sentry
+      - SENTRY_DSN_FRONTEND=https://abcdef0123456789abcdef0123456789@o-fake-dsn.ingest.sentry.io/1234567890123456
     volumes:
       - ../../files/nginx/odk.conf.template:/usr/share/odk/nginx/odk.conf.template:ro
       - ../../files/nginx/client-config.json.template:/usr/share/odk/nginx/client-config.json.template:ro

--- a/test/nginx/src/mocha/nginx.spec.js
+++ b/test/nginx/src/mocha/nginx.spec.js
@@ -442,7 +442,7 @@ function standardTestSuite({ fetchHttp, fetchHttp6, apiFetch, apiFetch6, forward
 
     // then
     assert.equal(res.status, 200);
-    assert.deepEqual(await res.json(), { oidcEnabled: false, sentryDsn: 'https://fake-dsn.fake-sentry' });
+    assert.deepEqual(await res.json(), { oidcEnabled:false, sentryDsn:'https://abcdef0123456789abcdef0123456789@o-fake-dsn.ingest.sentry.io/1234567890123456' });
     assertSecurityHeaders(res, { csp:'central-frontend' });
   });
 
@@ -452,7 +452,7 @@ function standardTestSuite({ fetchHttp, fetchHttp6, apiFetch, apiFetch6, forward
 
     // then
     assert.equal(res.status, 200);
-    assert.deepEqual(await res.json(), { oidcEnabled: false, sentryDsn: 'https://fake-dsn.fake-sentry' });
+    assert.deepEqual(await res.json(), { oidcEnabled:false, sentryDsn:'https://abcdef0123456789abcdef0123456789@o-fake-dsn.ingest.sentry.io/1234567890123456' });
     assertSecurityHeaders(res, { csp:'central-frontend' });
   });
 


### PR DESCRIPTION
This realism will become more important in future test scenarios and nginx configuration.

#### What has been done to verify that this works as intended?

- [x] tested locally
- [x] tested in ci

#### Why is this the best possible solution? Were any other approaches considered?

Current test value for `SENTRY_DSN_FRONTEND` is unrealistic, which may affect tested behaviours.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No impact - just a test change.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.