### PR TITLE
fix(#2086): downgrade Enketo to 7.6.1

### DIFF
--- a/enketo.dockerfile
+++ b/enketo.dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/enketo/enketo:7.6.2
+FROM ghcr.io/enketo/enketo:7.6.1
 
 ENV ENKETO_SRC_DIR=/srv/src/enketo/packages/enketo-express
 WORKDIR ${ENKETO_SRC_DIR}


### PR DESCRIPTION
> [!WARNING]
> Branch off and target `next`, not `master`. The `master` is stable and used in production (exception: documentation/infrastructure-only changes).

Closes #2086

#### What has been done to verify that this works as intended?
CI passess and I checked how it was done in https://github.com/getodk/central/pull/1965

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.
