### PR TITLE
Update FRONTEND_VERSION for v2026.2.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,7 +97,7 @@ services:
       dockerfile: nginx.dockerfile
       args:
         FRONTEND_BUILD_MODE: ${FRONTEND_BUILD_MODE:-fetch}
-        FRONTEND_VERSION: v2026.2.0
+        FRONTEND_VERSION: v2026.2.1
     depends_on:
       - service
       - enketo


### PR DESCRIPTION
This PR prepares the patch release v2026.2.1. It updates `FRONTEND_VERSION`.

#### What has been done to verify that this works as intended?

The patch release hasn't actually been tagged yet in the `central-frontend` repo, so it is expected that CI currently fails on this branch. We can rerun CI once the release has been tagged in `central-frontend`. Alternatively, we could check CI on the `next` branch once this PR is merged to `next`. Either way, let's merge this PR to `next` only once the release has been tagged.

#### Why is this the best possible solution? Were any other approaches considered?

Even though the release hasn't been tagged yet in `central-frontend`, I think it's OK to go ahead and review this PR. It's just one version number changing to another. You can compare this PR with the following previous PR: #2039