### PR TITLE
Update news for v2026.2.1

### DIFF
--- a/docs/news.html
+++ b/docs/news.html
@@ -7,7 +7,7 @@
   </head>
   <body>
     <div class="news-item">
-      <span class="item-date">2026/07/30</span>
+      <span class="item-date">2026/07/31</span>
       <a href="https://forum.getodk.org/t/58254/3" target="_blank">
         ODK Central v2026.2.1
       </a>

--- a/docs/news.html
+++ b/docs/news.html
@@ -7,15 +7,15 @@
   </head>
   <body>
     <div class="news-item">
-      <span class="item-date">2026/07/03</span>
-      <a href="https://forum.getodk.org/t/58254" target="_blank">
-        ODK Central v2026.2.0
+      <span class="item-date">2026/07/30</span>
+      <a href="https://forum.getodk.org/t/58254/3" target="_blank">
+        ODK Central v2026.2.1
       </a>
     </div>
     <div class="news-item">
-      <span class="item-date">2026/05/04</span>
-      <a href="https://forum.getodk.org/t/57925/6" target="_blank">
-        ODK Central v2026.1.2
+      <span class="item-date">2026/07/03</span>
+      <a href="https://forum.getodk.org/t/58254" target="_blank">
+        ODK Central v2026.2.0
       </a>
     </div>
     <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "81f288331d6e4638be205e0e63388165"}'></script>


### PR DESCRIPTION
This PR prepares the patch release v2026.2.1 by updating news.html.

This PR intentionally targets the `master` branch, not `next`. That's because (1) it's not a code change that affects deployments (it's arguably closer to documentation), and (2) we will merge `next` into `master` and tag the release before then merging this PR into `master` (i.e., we release first, then announce in news).

#### What has been done to verify that this works as intended?

I followed the usual patterns, but I didn't do anything special to verify.