### PR TITLE
chore: split release issue template 

### DIFF
--- a/.github/ISSUE_TEMPLATE/patch_release.md
+++ b/.github/ISSUE_TEMPLATE/patch_release.md
@@ -7,7 +7,7 @@ labels: ''
 assignees: ''
 ---
 
-Complete the steps below to release a patch version of ODK Central.
+Complete the steps below to release a patch version of ODK Central. For a major release, use the **Release** issue template instead.
 
 > **Legend**
 > - 🔎 Requires the second person (reviewer)

--- a/.github/ISSUE_TEMPLATE/patch_release.md
+++ b/.github/ISSUE_TEMPLATE/patch_release.md
@@ -55,14 +55,15 @@ Releasing requires two people: one person to push PRs and complete other tasks a
   - Set as the **latest release**. Don't set as a pre-release.
   - Body: a single line pointing to the upcoming `central` release, e.g., `See release notes at https://github.com/getodk/central/releases/tag/vX.Y.Z`.
 
-### Update submodules
+### Update versions
 
-- [ ] For each of the server and client submodules, `cd` into the directory and run:
+- [ ] If the patch includes `central-backend` changes, `cd server` and run:
   - `git fetch`
   - `git switch -d origin/master` or `git checkout origin/master`
-- [ ] Commit the submodule updates using a new branch (e.g., `update-submodules`). Create a new PR for the branch.
-  - If the only change/PR to the `central` repository is the submodule updates, target the `master` branch. Otherwise, a different branch will be used for the patch (possibly `next`); target that branch.
-- [ ] 🔎 Review the PR. For each submodule, the diff in GitHub will link to a page that indicates the old and new commit hashes.
+- [ ] If the patch includes `central-frontend` changes, update `FRONTEND_VERSION` in `docker-compose.yml` to the tag of the `central-frontend` release created above.
+- [ ] Commit the updates using a new branch (e.g., `update-versions`). Create a new PR for the branch.
+  - If the only change/PR to the `central` repository is these updates, target the `master` branch. Otherwise, a different branch will be used for the patch (possibly `next`); target that branch.
+- [ ] 🔎 Review the PR. Verify that the `server` diff links to the expected commit hashes and that `FRONTEND_VERSION` matches the `central-frontend` release tag.
 
 ### Merge
 

--- a/.github/ISSUE_TEMPLATE/patch_release.md
+++ b/.github/ISSUE_TEMPLATE/patch_release.md
@@ -1,13 +1,13 @@
 ---
-name: Release
-about: Checklist for releasing a new major version of ODK Central
-title: 'Release vXXXX.X.0'
+name: Patch release
+about: Checklist for releasing a patch version of ODK Central
+title: 'Patch release vXXXX.X.Y'
 type: 'Task'
 labels: ''
 assignees: ''
 ---
 
-Complete the steps below to release a new major version of ODK Central. For a patch release, use the **Patch release** issue template instead.
+Complete the steps below to release a patch version of ODK Central.
 
 > **Legend**
 > - 🔎 Requires the second person (reviewer)
@@ -20,18 +20,17 @@ Releasing requires two people: one person to push PRs and complete other tasks a
 
 - [ ] Decide the release version (`vXXXX.X.Y`). The same version is used for `central`, `central-backend`, and `central-frontend`, so the `central` release URL (`https://github.com/getodk/central/releases/tag/vXXXX.X.Y`) can be referenced from the `central-frontend` and `central-backend` release bodies.
 - [ ] Write an announcement about the release for the forum.
-- [ ] Create a new topic in the forum for the release. Use the **Scheduled** category and add the `odk-central` label.
 
 ### Get the repository
 
 - [ ] Get the latest version of the `central` repository locally.
   - If you have **not** cloned the repository: clone it.
   - If you had **already** cloned the repository: `git pull`
-- [ ] Check out the `next` branch.
+- [ ] Check out the correct branch. If the patch involves a single change/PR to the `central` repository, check out the `master` branch. Otherwise, a different branch will be used for the patch (possibly `next`); check out that branch.
 
 ### Release `central-frontend`
 
-> Major releases always include `central-frontend`.
+> Optional section: skip it if no `central-frontend` changes are included in the patch.
 
 - [ ] Run `npm run version` in `central-frontend`. This consumes the `.changeset/` files, bumps package versions, and updates each `CHANGELOG.md`.
 - [ ] Commit the changes on a new branch (e.g., `release-version-bumps`) and open a PR targeting `master`.
@@ -49,11 +48,10 @@ Releasing requires two people: one person to push PRs and complete other tasks a
 
 ### Release `central-backend`
 
-> Major releases always include `central-backend`.
+> Optional section: skip it if no `central-backend` changes are included in the patch.
 
 - [ ] Create a GitHub release on the latest `master` commit of `central-backend`.
   - Tag: `v*.*.*` (no pre-release suffix).
-  - Don't forget the final `XXXX.X.0` in the tag and release title.
   - Set as the **latest release**. Don't set as a pre-release.
   - Body: a single line pointing to the upcoming `central` release, e.g., `See release notes at https://github.com/getodk/central/releases/tag/vX.Y.Z`.
 
@@ -63,35 +61,27 @@ Releasing requires two people: one person to push PRs and complete other tasks a
   - `git fetch`
   - `git switch -d origin/master` or `git checkout origin/master`
 - [ ] Commit the submodule updates using a new branch (e.g., `update-submodules`). Create a new PR for the branch.
-  - Target the `next` branch.
+  - If the only change/PR to the `central` repository is the submodule updates, target the `master` branch. Otherwise, a different branch will be used for the patch (possibly `next`); target that branch.
 - [ ] 🔎 Review the PR. For each submodule, the diff in GitHub will link to a page that indicates the old and new commit hashes.
 
 ### Merge
 
-- [ ] Once the submodules PR has been merged into the `next` branch, use the existing release PR to merge `next` into the `master` branch.
+- [ ] If the patch involves more than a single change/PR to the `central` repository, then there should be a PR for the patch as a whole. Merge it.
   - Select **"Create a merge commit"** when you merge.
-  - Don't delete the `next` branch after merging.
+  - If the PR used the `next` branch, don't delete the `next` branch after merging.
 
 ### Release `central`
 
 - [ ] Create a GitHub release for `central`. This will also create a Git tag.
-  - Don't forget the final `XXXX.X.0` in the tag and release title.
   - Set as the **latest release**. Don't set as a pre-release.
   - Publish once you're ready to create the release and tag.
 - [ ] Add release notes to the release.
-  - Link to the release announcement in the forum.
 
   <details>
   <summary>📋 Release notes template — expand, fill in links, and paste into the GitHub release</summary>
 
   ```markdown
   ## Release Notes
-
-  📢 **[Read the official release announcement on the Forum!](insert-forum-link-here)**
-
-  We highly recommend checking out the forum post for a user-friendly overview of new features, enhanced with screenshots and guides.
-
-  ---
 
   ### 🛠 Technical Changelogs
   For a detailed list of technical updates, fixes, and improvements, please review the specific changelogs below:
@@ -116,7 +106,7 @@ Releasing requires two people: one person to push PRs and complete other tasks a
 
 ### Announce the release
 
-- [ ] Move the forum topic from the **Scheduled** category to the **Releases** category.
+- [ ] Reply to the topic for the latest release.
 
 ### Update news
 
@@ -128,4 +118,4 @@ Releasing requires two people: one person to push PRs and complete other tasks a
 
 > Do this once the news PR has been merged.
 
-- [ ] Reset the `next` branch to the tip of the `master` branch. The `master` branch will be ahead of the `next` branch, so this doesn't require a force-push.
+- [ ] If there has been a commit to the `next` branch that isn't on the `master` branch, then merge the `master` branch into the `next` branch. If there has not been a commit, then reset the `next` branch to the tip of the `master` branch.

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -18,7 +18,7 @@ Releasing requires two people: one person to push PRs and complete other tasks a
 
 ## Steps
 
-- [ ] Decide the release version (`vXXXX.X.Y`). The same version is used for `central`, `central-backend`, and `central-frontend`, so the `central` release URL (`https://github.com/getodk/central/releases/tag/vXXXX.X.Y`) can be referenced from the `central-frontend` and `central-backend` release bodies.
+- [ ] Decide the release version (`vXXXX.X.0`). The same version is used for `central`, `central-backend`, and `central-frontend`, so the `central` release URL (`https://github.com/getodk/central/releases/tag/vXXXX.X.0`) can be referenced from the `central-frontend` and `central-backend` release bodies.
 - [ ] Write an announcement about the release for the forum.
 - [ ] Create a new topic in the forum for the release. Use the **Scheduled** category and add the `odk-central` label.
 

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -1,13 +1,13 @@
 ---
 name: Release
-about: Checklist for releasing a new major version of ODK Central
+about: Checklist for releasing a new version of ODK Central
 title: 'Release vXXXX.X.0'
 type: 'Task'
 labels: ''
 assignees: ''
 ---
 
-Complete the steps below to release a new major version of ODK Central. For a patch release, use the **Patch release** issue template instead.
+Complete the steps below to release a new version of ODK Central. For a patch release, use the **Patch release** issue template instead.
 
 > **Legend**
 > - 🔎 Requires the second person (reviewer)
@@ -31,7 +31,7 @@ Releasing requires two people: one person to push PRs and complete other tasks a
 
 ### Release `central-frontend`
 
-> Major releases always include `central-frontend`.
+> Releases always include `central-frontend`.
 
 - [ ] Run `npm run version` in `central-frontend`. This consumes the `.changeset/` files, bumps package versions, and updates each `CHANGELOG.md`.
 - [ ] Commit the changes on a new branch (e.g., `release-version-bumps`) and open a PR targeting `master`.
@@ -49,7 +49,7 @@ Releasing requires two people: one person to push PRs and complete other tasks a
 
 ### Release `central-backend`
 
-> Major releases always include `central-backend`.
+> Releases always include `central-backend`.
 
 - [ ] Create a GitHub release on the latest `master` commit of `central-backend`.
   - Tag: `v*.*.*` (no pre-release suffix).
@@ -57,18 +57,19 @@ Releasing requires two people: one person to push PRs and complete other tasks a
   - Set as the **latest release**. Don't set as a pre-release.
   - Body: a single line pointing to the upcoming `central` release, e.g., `See release notes at https://github.com/getodk/central/releases/tag/vX.Y.Z`.
 
-### Update submodules
+### Update versions
 
-- [ ] For each of the server and client submodules, `cd` into the directory and run:
+- [ ] `cd server` and run:
   - `git fetch`
   - `git switch -d origin/master` or `git checkout origin/master`
-- [ ] Commit the submodule updates using a new branch (e.g., `update-submodules`). Create a new PR for the branch.
+- [ ] Update `FRONTEND_VERSION` in `docker-compose.yml` to the tag of the `central-frontend` release created above.
+- [ ] Commit the updates using a new branch (e.g., `update-versions`). Create a new PR for the branch.
   - Target the `next` branch.
-- [ ] 🔎 Review the PR. For each submodule, the diff in GitHub will link to a page that indicates the old and new commit hashes.
+- [ ] 🔎 Review the PR. Verify that the `server` diff links to the expected commit hashes and that `FRONTEND_VERSION` matches the `central-frontend` release tag.
 
 ### Merge
 
-- [ ] Once the submodules PR has been merged into the `next` branch, use the existing release PR to merge `next` into the `master` branch.
+- [ ] Once the versions PR has been merged into the `next` branch, use the existing release PR to merge `next` into the `master` branch.
   - Select **"Create a merge commit"** when you merge.
   - Don't delete the `next` branch after merging.
 


### PR DESCRIPTION
> [!WARNING]
> Branch off and target `next`, not `master`. The `master` is stable and used in production (exception: documentation/infrastructure-only changes).

#### What has been done to verify that this works as intended?

Followed the pattern of the other issue templates and double-checked that no steps are missing

#### Why is this the best possible solution? Were any other approaches considered?

Initially, it was Gareth's feedback, but after the recent release, I often read the steps and wondered whether they apply to patch or major releases. I believe this makes it easier to follow with less cognitive load.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No
