### PR TITLE
chore: update news for 2026.2.2

### DIFF
--- a/docs/news.html
+++ b/docs/news.html
@@ -7,15 +7,15 @@
   </head>
   <body>
     <div class="news-item">
-      <span class="item-date">2026/07/31</span>
-      <a href="https://forum.getodk.org/t/58254/3" target="_blank">
-        ODK Central v2026.2.1
+      <span class="item-date">2026/08/11</span>
+      <a href="https://forum.getodk.org/t/58254/4" target="_blank">
+        ODK Central v2026.2.2
       </a>
     </div>
     <div class="news-item">
-      <span class="item-date">2026/07/03</span>
-      <a href="https://forum.getodk.org/t/58254" target="_blank">
-        ODK Central v2026.2.0
+      <span class="item-date">2026/07/31</span>
+      <a href="https://forum.getodk.org/t/58254/3" target="_blank">
+        ODK Central v2026.2.1
       </a>
     </div>
     <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "81f288331d6e4638be205e0e63388165"}'></script>


### PR DESCRIPTION
> [!WARNING]
> Branch off and target `next`, not `master`. The `master` is stable and used in production (exception: documentation/infrastructure-only changes).

Getting ready...