### PR TITLE
chore: update client and server for v2026.2.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,7 +97,7 @@ services:
       dockerfile: nginx.dockerfile
       args:
         FRONTEND_BUILD_MODE: ${FRONTEND_BUILD_MODE:-fetch}
-        FRONTEND_VERSION: v2026.2.1
+        FRONTEND_VERSION: v2026.2.2
     depends_on:
       - service
       - enketo


### PR DESCRIPTION
> [!WARNING]
> Branch off and target `next`, not `master`. The `master` is stable and used in production (exception: documentation/infrastructure-only changes).

Closes #

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.
