### PR TITLE
chore: add news for 2026.2.3

### DIFF
--- a/docs/news.html
+++ b/docs/news.html
@@ -8,8 +8,8 @@
   <body>
     <div class="news-item">
       <span class="item-date">2026/08/11</span>
-      <a href="https://forum.getodk.org/t/58254/4" target="_blank">
-        ODK Central v2026.2.2
+      <a href="https://forum.getodk.org/t/58254/5" target="_blank">
+        ODK Central v2026.2.3
       </a>
     </div>
     <div class="news-item">


### PR DESCRIPTION
I decided to just ignore 2026.2.2 altogether.
