### PR TITLE
test/nginx/setup-odk: increase global teardown timeout

### DIFF
--- a/test/nginx/src/mocha/setup-odk.spec.js
+++ b/test/nginx/src/mocha/setup-odk.spec.js
@@ -13,7 +13,8 @@ describe('setup-odk.sh', function() {
       dockerCompose({}, `logs --timestamps ${service}`);
       log('--- END CONTAINER LOGS ---');
     });
-    after(() => {
+    after(function() {
+      this.timeout(5000);
       dockerCompose({}, `down --remove-orphans --volumes`);
     });
 


### PR DESCRIPTION
Seen to timeout after 2.1 seconds: https://github.com/getodk/central/actions/runs/31661302771/job/94326512906?pr=2104

Ref #2104

#### What has been done to verify that this works as intended?

- [x] ci

I didn't bother running exhaustively, as it seems like a simple change.  And if there's a problem, a new fix should also be simple.

#### Why is this the best possible solution? Were any other approaches considered?

Seems like a legit timeout, so increasing the timeout 2.5x seems like a decent buffer.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No effect or risk.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.