### PR TITLE
chore: update news for 2026.2.4

### DIFF
--- a/docs/news.html
+++ b/docs/news.html
@@ -7,15 +7,15 @@
   </head>
   <body>
     <div class="news-item">
-      <span class="item-date">2026/08/11</span>
-      <a href="https://forum.getodk.org/t/58254/5" target="_blank">
-        ODK Central v2026.2.3
+      <span class="item-date">2026/08/21</span>
+      <a href="https://forum.getodk.org/t/58254/6" target="_blank">
+        ODK Central v2026.2.4
       </a>
     </div>
     <div class="news-item">
-      <span class="item-date">2026/07/31</span>
-      <a href="https://forum.getodk.org/t/58254/3" target="_blank">
-        ODK Central v2026.2.1
+      <span class="item-date">2026/08/11</span>
+      <a href="https://forum.getodk.org/t/58254/5" target="_blank">
+        ODK Central v2026.2.3
       </a>
     </div>
     <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "81f288331d6e4638be205e0e63388165"}'></script>


### PR DESCRIPTION
> [!WARNING]
> Branch off and target `next`, not `master`. The `master` is stable and used in production (exception: documentation/infrastructure-only changes).

Closes #

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.
