### PR TITLE
nginx/csp: add tests for frame-src & frame-ancestors

### DIFF
--- a/test/nginx/mock-sentry/index.js
+++ b/test/nginx/mock-sentry/index.js
@@ -28,6 +28,14 @@ app.use(express.json({
   ],
 }));
 app.get('/__mock_sentry/event-log', (req, res) => res.json(events));
+app.get('/__mock_sentry/no-csp', (req, res) => {
+  // Not really Sentry-related, but a useful page for random tests which require
+  // a browser context on a 3rd-party domain.
+  res.set('Content-Type', 'text/html');
+  res.removeHeader('Content-Security-Policy');
+  res.removeHeader('Content-Security-Policy-Report-Only');
+  res.send('<html><body></body></html>');
+});
 app.get('/__mock_sentry/reset',       (req, res) => {
   events.length = 0;
   res.json('OK');

--- a/test/nginx/src/lib.js
+++ b/test/nginx/src/lib.js
@@ -8,16 +8,21 @@ const { assert } = chai;
 module.exports = {
   assert,
   assertSentryReceived,
+  getReceivedSentryCspReports,
   requestSentryMock,
   resetSentryMock,
   sleep,
 };
 
-async function assertSentryReceived(...expectedRequests) {
+async function getReceivedSentryCspReports() {
   const { status, body } = await requestSentryMock({ path:'/__mock_sentry/event-log' });
   assert.equal(status, 200);
 
-  const actual = JSON.parse(body);
+  return JSON.parse(body);
+}
+
+async function assertSentryReceived(...expectedRequests) {
+  const actual = await getReceivedSentryCspReports();
 
   try {
     assert.deepEqual(actual, expectedRequests);

--- a/test/nginx/src/playwright/csp.spec.js
+++ b/test/nginx/src/playwright/csp.spec.js
@@ -1,9 +1,12 @@
+/* global document */
+
 const assert = require('node:assert/strict');
 
 const { test }  = require('@playwright/test');
 
 const {
   assertSentryReceived,
+  getReceivedSentryCspReports,
   resetSentryMock,
 } = require('../lib');
 
@@ -75,7 +78,6 @@ test('catches style-src-elem violation samples', async ({ page }) => {
 
   // when
   await page.evaluate(() => {
-    /* global document */
     const style = document.createElement('style');
     style.textContent = 'body { background-color:red }';
     document.head.appendChild(style);
@@ -95,7 +97,7 @@ test('catches style-src-elem violation samples', async ({ page }) => {
           'original-policy': `default-src 'report-sample' 'none'; connect-src 'self' https://o-fake-dsn.ingest.sentry.io https://translate.google.com https://translate.googleapis.com; font-src 'self'; form-action 'self'; frame-ancestors 'none'; frame-src 'self' https://getodk.github.io/central/; img-src data: https:; manifest-src 'self'; media-src 'none'; object-src 'none'; script-src 'report-sample' 'self'; style-src 'report-sample' 'self'; style-src-attr 'unsafe-inline'; worker-src 'report-sample' blob:; report-uri /csp-report`,
           'disposition': 'enforce',
           'blocked-uri': 'inline',
-          'line-number': 5,
+          'line-number': 4,
           'column-number': 19,
           'status-code': 200,
           'script-sample': 'body { background-color:red }',
@@ -103,6 +105,153 @@ test('catches style-src-elem violation samples', async ({ page }) => {
       },
     },
   );
+});
+
+test.describe('frame rules', () => {
+  const HOSTS = {
+    odkCentral: { origin:'https://odk-nginx.example.test:9001/', path:'' },
+    thirdParty: { origin:'https://o-fake-dsn.ingest.sentry.io',  path:'/__mock_sentry/no-csp' },
+  };
+  const ALL_HOSTS = Object.keys(HOSTS);
+
+  [
+    {
+      description: 'central-backend',
+      centralUrl: 'https://odk-nginx.example.test:9001/v1/projects',
+      allowedFrameAncestors: [ /*none*/ ],
+      allowedFrameDestinations: [ /*none*/ ],
+    },
+    {
+      description: 'central-frontend',
+      centralUrl: 'https://odk-nginx.example.test:9001/',
+      allowedFrameAncestors: [ /*none*/ ],
+      allowedFrameDestinations: [
+        'odkCentral',
+      ],
+    },
+    {
+      description: 'blank-page',
+      centralUrl: 'https://odk-nginx.example.test:9001/blank.html',
+      allowedFrameAncestors: [
+        'odkCentral',
+      ],
+      allowedFrameDestinations: [ /*none*/ ],
+    },
+    {
+      description: 'enketo',
+      centralUrl: 'https://odk-nginx.example.test:9001/-/some/enketo/path',
+      allowedFrameAncestors: [
+        'odkCentral',
+      ],
+      allowedFrameDestinations: [ /*none*/ ],
+    },
+    {
+      description: 'form-wrapper',
+      centralUrl: 'https://odk-nginx.example.test:9001/projects/1/xml-form-id/submissions/new',
+      allowedFrameAncestors: [ /*none*/ ],
+      allowedFrameDestinations: [
+        'odkCentral',
+      ],
+    },
+    {
+      description: 'oidc-callback',
+      centralUrl: 'https://odk-nginx.example.test:9001/v1/oidc/callback',
+      // Nothing is exlicitly disallowed here, because this URL is left
+      // to manage its own Content-Security-Policy headers.
+      allowedFrameAncestors: ALL_HOSTS,
+      allowedFrameDestinations: ALL_HOSTS,
+    },
+  ].forEach(({ description, centralUrl, allowedFrameDestinations, allowedFrameAncestors }) => {
+    if(!allowedFrameAncestors.every(allowed => ALL_HOSTS.includes(allowed)))
+      throw new Error(`Unrecognised frame ancestors(s) whitelisted: ${JSON.stringify({ allowedFrameAncestors, validFrameAncestors: ALL_HOSTS })}`);
+    if(!allowedFrameDestinations.every(allowed => ALL_HOSTS.includes(allowed)))
+      throw new Error(`Unrecognised frame destination(s) whitelisted: ${JSON.stringify({ allowedFrameDestinations, validFrameDestinations: ALL_HOSTS })}`);
+
+    test.describe(`${description} (${centralUrl})`, () => {
+      for(const [ hostName, host ] of Object.entries(HOSTS)) {
+        const hostUrl = host.origin + host.path;
+        const allowFrameAncestor = allowedFrameAncestors.includes(hostName);
+        test(`frame-ancestors ${allowFrameAncestor ? 'should' : 'should NOT'} allow "${hostName}" (${hostUrl})`, async ({ page }) => {
+          // given
+          await page.goto(hostUrl);
+
+          // when
+          await page.evaluate(({ centralUrl }) => {
+            const frame = document.createElement('iframe');
+            frame.src = centralUrl;
+            document.head.appendChild(frame);
+          }, { centralUrl });
+          // and
+          await new Promise(resolve => setTimeout(resolve, 100));
+
+          // then
+          if(allowFrameAncestor) {
+            await assertSentryReceived(/* nothing */);
+          } else {
+            const receivedSentryReports = await getReceivedSentryCspReports();
+            receivedSentryReports.forEach(r => delete r.report['csp-report']['original-policy']);
+            assert.deepEqual(receivedSentryReports, [
+              {
+                'report': {
+                  'csp-report': {
+                    'document-uri': new URL(centralUrl).origin + '/',
+                    'referrer': '',
+                    'violated-directive': 'frame-ancestors',
+                    'effective-directive': 'frame-ancestors',
+                    'disposition': 'enforce',
+                    'blocked-uri': new URL(centralUrl).origin + '/',
+                    'status-code': 200,
+                    'script-sample': '',
+                  },
+                },
+              },
+            ]);
+          }
+        });
+
+        const allowFrameSrc = allowedFrameDestinations.includes(hostName);
+        test(`frame-src ${allowFrameSrc ? 'should' : 'should NOT'} allow "${hostName}" (${hostUrl})`, async ({ page }) => {
+          // given
+          await page.goto(centralUrl);
+
+          // when
+          await page.evaluate(({ hostUrl }) => {
+            const frame = document.createElement('iframe');
+            frame.src = hostUrl;
+            document.head.appendChild(frame);
+          }, { hostUrl });
+          // and
+          await new Promise(resolve => setTimeout(resolve, 100));
+
+          // then
+          const receivedSentryReports = (await getReceivedSentryCspReports())
+              // ignore frame-ancestors rules - they kick in after frame-src rules have been checked
+              .filter(r => r.report['csp-report']['violated-directive'] !== 'frame-ancestors');
+          if(allowFrameSrc) {
+            assert.deepEqual(receivedSentryReports, [ /*nothing*/ ]);
+          } else {
+            receivedSentryReports.forEach(r => delete r.report['csp-report']['original-policy']);
+            assert.deepEqual(receivedSentryReports, [
+              {
+                'report': {
+                  'csp-report': {
+                    'document-uri': centralUrl,
+                    'referrer': '',
+                    'violated-directive': 'frame-src',
+                    'effective-directive': 'frame-src',
+                    'disposition': 'enforce',
+                    'blocked-uri': host.origin,
+                    'status-code': 200,
+                    'script-sample': '',
+                  },
+                },
+              },
+            ]);
+          }
+        });
+      }
+    });
+  });
 });
 
 function stripLeadingSlash(path) {

--- a/test/nginx/src/playwright/csp.spec.js
+++ b/test/nginx/src/playwright/csp.spec.js
@@ -179,7 +179,7 @@ test.describe('frame rules', () => {
           await page.evaluate(({ centralUrl }) => {
             const frame = document.createElement('iframe');
             frame.src = centralUrl;
-            document.head.appendChild(frame);
+            document.body.appendChild(frame);
           }, { centralUrl });
           // and
           await new Promise(resolve => setTimeout(resolve, 100));
@@ -218,7 +218,7 @@ test.describe('frame rules', () => {
           await page.evaluate(({ hostUrl }) => {
             const frame = document.createElement('iframe');
             frame.src = hostUrl;
-            document.head.appendChild(frame);
+            document.body.appendChild(frame);
           }, { hostUrl });
           // and
           await new Promise(resolve => setTimeout(resolve, 100));

--- a/test/nginx/src/playwright/csp.spec.js
+++ b/test/nginx/src/playwright/csp.spec.js
@@ -147,7 +147,7 @@ test.describe('frame rules', () => {
     },
     {
       description: 'form-wrapper',
-      centralUrl: 'https://odk-nginx.example.test:9001/projects/1/xml-form-id/submissions/new',
+      centralUrl: 'https://odk-nginx.example.test:9001/projects/1/forms/xml-form-id/submissions/new',
       allowedFrameAncestors: [ /*none*/ ],
       allowedFrameDestinations: [
         'odkCentral',

--- a/test/nginx/src/playwright/csp.spec.js
+++ b/test/nginx/src/playwright/csp.spec.js
@@ -148,7 +148,9 @@ test.describe('frame rules', () => {
     {
       description: 'form-wrapper',
       centralUrl: 'https://odk-nginx.example.test:9001/projects/1/forms/xml-form-id/submissions/new',
-      allowedFrameAncestors: [ /*none*/ ],
+      allowedFrameAncestors: [
+        'odkCentral',
+      ],
       allowedFrameDestinations: [
         'odkCentral',
       ],


### PR DESCRIPTION
Setup for #2080 

#### What has been done to verify that this works as intended?

- [x] ran locally
- [x] CI

#### Why is this the best possible solution? Were any other approaches considered?

No other approaches considered.  These tests are brought in as set-up to changing frame rules (e.g. https://github.com/getodk/central/pull/2155, #2080).

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No change - just tests.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.