### PR TITLE
Upgrade Enketo to 7.6.4

### DIFF
--- a/enketo.dockerfile
+++ b/enketo.dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/enketo/enketo:7.6.1
+FROM ghcr.io/enketo/enketo:7.6.4
 
 ENV ENKETO_SRC_DIR=/srv/src/enketo/packages/enketo-express
 WORKDIR ${ENKETO_SRC_DIR}

--- a/files/enketo/config.json.template
+++ b/files/enketo/config.json.template
@@ -34,6 +34,12 @@
     "support": {
         "email": "support@getodk.org"
     },
+    "maps": [ {
+        "name": "street",
+        "tiles": [ "https://tile.openstreetmap.org/{z}/{x}/{y}.png" ],
+        "attribution": "Map data © <a href=\"http://openstreetmap.org\">OpenStreetMap</a> contributors",
+        "referrerPolicy": "origin"
+    } ],
     "text field character limit": 1000000,
     "exclude non-relevant": true,
     "hide powered by": true


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/1885 Closes https://github.com/getodk/central/issues/2071

Because the Enketo default map config does not set `referrerPolicy`, we need to add a map config block.

#### What has been done to verify that this works as intended?
Upgraded to 7.6.4 on dev. Verified that Google Maps works. Verified that OSM with explicit referrerPolicy configuration works. 

While doing this I noticed that OSM tiles don't work with an /x/ "offlineable" form. I see a `NS_ERROR_INTERCEPTION_FAILED` error. This happens with 7.6.1 as well so I don't think we need to do anything about it. Cloud is unaffected because it uses Google Maps.

#### Why is this the best possible solution? Were any other approaches considered?

I considered seeing whether we should add `referrerPolicy` to the default Enketo maps config but I think this is ok.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

I looked at the Enketo release notes and associated code changes and I think they're overall low-risk. The dynamic read-only doesn't appear to be complete (e.g. dates don't become read-only) but that's no worse than it was before.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No. Enketo docs have been updated for self-hosters who manage their own config.