### PR TITLE
chore: update patch release template with issue checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/patch_release.md
+++ b/.github/ISSUE_TEMPLATE/patch_release.md
@@ -20,7 +20,7 @@ Releasing requires two people: one person to push PRs and complete other tasks a
 
 - [ ] Decide the release version (`vXXXX.X.Y`). The same version is used for `central`, `central-backend`, and `central-frontend`, so the `central` release URL (`https://github.com/getodk/central/releases/tag/vXXXX.X.Y`) can be referenced from the `central-frontend` and `central-backend` release bodies.
 - [ ] List all the issues in `central` and `web-forms` repos to be included in this release, and tick them off when they have been cherry-picked into the release branch
-  - [ ] <!-- first issue -->
+  - [ ] {{ first issue }}
 
 ### Get the repository
 

--- a/.github/ISSUE_TEMPLATE/patch_release.md
+++ b/.github/ISSUE_TEMPLATE/patch_release.md
@@ -19,7 +19,8 @@ Releasing requires two people: one person to push PRs and complete other tasks a
 ## Steps
 
 - [ ] Decide the release version (`vXXXX.X.Y`). The same version is used for `central`, `central-backend`, and `central-frontend`, so the `central` release URL (`https://github.com/getodk/central/releases/tag/vXXXX.X.Y`) can be referenced from the `central-frontend` and `central-backend` release bodies.
-- [ ] Write an announcement about the release for the forum.
+- [ ] List all the issues in `central` and `web-forms` repos to be included in this release, and tick them off when they have been cherry-picked into the release branch
+  - [ ] <!-- first issue -->
 
 ### Get the repository
 


### PR DESCRIPTION
> [!WARNING]
> Branch off and target `next`, not `master`. The `master` is stable and used in production (exception: documentation/infrastructure-only changes).

Closes #

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.
