### PR TITLE
upgrade-postgres: clarify data cleanup link

### DIFF
--- a/files/postgres/upgrade-postgres.sh
+++ b/files/postgres/upgrade-postgres.sh
@@ -28,7 +28,7 @@ if [[ -f "$flag_upgradeCompletedOk" ]]; then
     log "!!!"
     log "!!! This is taking up disk space: $(du -hs "$PGDATAOLD" 2>/dev/null | cut -f1)B"
     log "!!!"
-    log "!!! Continue with the instructions at https://docs.getodk.org/central-upgrade/"
+    log "!!! Continue with the instructions at https://docs.getodk.org/central-upgrade/#upgrading-to-central-v2023-2
     log "!!!"
   fi
 else

--- a/files/postgres/upgrade-postgres.sh
+++ b/files/postgres/upgrade-postgres.sh
@@ -28,7 +28,7 @@ if [[ -f "$flag_upgradeCompletedOk" ]]; then
     log "!!!"
     log "!!! This is taking up disk space: $(du -hs "$PGDATAOLD" 2>/dev/null | cut -f1)B"
     log "!!!"
-    log "!!! Continue with the instructions at https://docs.getodk.org/central-upgrade/#upgrading-to-central-v2023-2
+    log "!!! Continue with the instructions at https://docs.getodk.org/central-upgrade/#upgrading-to-central-v2023-2"
     log "!!!"
   fi
 else


### PR DESCRIPTION
In the original implementation (https://github.com/getodk/central/pull/343), old postgres data was cleaned up automatically if a specific flag file was present.

This behaviour was changed (prior to release?) in a follow-up PR (https://github.com/getodk/central/pull/395) to link to documentation instead.

Over time, it's become less clear which part of the linked documentation is relevant.  This PR aims to link more directly to the relevant documentation.

#### What has been done to verify that this works as intended?

- [x] clicked the link
- [x] ci
- [x] not much else

#### Why is this the best possible solution? Were any other approaches considered?

It took me a while to understand which part of the original link (https://docs.getodk.org/central-upgrade/) was relevant to upgrading postgres.  The new link is https://docs.getodk.org/central-upgrade/#upgrading-to-central-v2023-2

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

Hopefully gets them where they need to be quicker.  Low risk of regression.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.